### PR TITLE
fix[#47] : github action 백엔드 배포 버그 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,4 +32,4 @@ jobs:
             cd ../server
             npm install
             npm run build
-            pm2 start ./dist/app.js
+            pm2 start npm -- start


### PR DESCRIPTION
- npm start로 실행했을 땐 되고 tsc로 빌드 후 pm2로 실행했을 땐 안되는
  버그 수정
- pm2로 npm start를 실행하게 바꿈