### PR TITLE
fix[#65] : SearchModal 옵션 클릭 Bugfix - close #65

### DIFF
--- a/client/src/common/search-modal/index.tsx
+++ b/client/src/common/search-modal/index.tsx
@@ -33,9 +33,10 @@ const ChipStyle = (checked: boolean) => {
 	return css`
 		width: 80px;
 		margin: 3px 3px;
-		${checked ? 'background-color: #ebabab;' : ''}
+		${checked ? 'background-color: #ebabab; color: #ffffff;' : ''}
 		&:hover {
-			background-color: #ffe7e7;
+			background-color: #ebe4e4;
+			${checked ? 'background-color: #ebabab;' : ''}
 		}
 	`;
 };


### PR DESCRIPTION
## Problem

[Issue #65 : 모바일 환경에서 SearchModal의 필터링 옵션을 클릭해도 색상 변경이 안되는 문제](https://github.com/boostcampwm-2021/WEB19-sajagachi/issues/65)

## Result

![after](https://user-images.githubusercontent.com/76616101/140397395-1349dc44-4815-47e6-867f-6fbcb7e35f9e.gif)
