### PR TITLE
feat[#73] : query string에 따라 필터의 상태 유지 - close #73

### DIFF
--- a/client/src/type/index.ts
+++ b/client/src/type/index.ts
@@ -17,7 +17,7 @@ export interface QueryStringType {
 	limit?: number;
 	category?: number[];
 	finished?: boolean | undefined;
-	lat?: number;
-	long?: number;
+	lat: number;
+	long: number;
 	search?: string;
 }

--- a/client/src/util/util.ts
+++ b/client/src/util/util.ts
@@ -64,14 +64,18 @@ export const dateFormat = (dateStr: string) => {
 };
 
 export const decomposeQueryString = (queryStr: string) => {
-	const result: QueryStringType = {};
+	const result: QueryStringType = {
+		lat: 0,
+		long: 0
+	};
 	const params = new URLSearchParams(queryStr);
 	result.category = params
 		.get('category')
 		?.split(',')
 		.map(x => Number(x));
+
 	result.finished = params.get('finished')
-		? Boolean(params.get('finished'))
+		? params.get('finished') === 'true'
 		: undefined;
 	result.lat = Number(params.get('lat'));
 	result.long = Number(params.get('long'));


### PR DESCRIPTION
- serch-modal/index.tsx 에서 useEffect 로 초기값을 queryString에 따라 세팅할 수 있도록 구현
- util의 decomposeQueryString type 오류 해결