### PR TITLE
게시글 상세 페이지 초기 UI 레이아웃 배치

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
 import Gnb from './common/gnb';
 import { Global, css } from '@emotion/react';
-import {
-	BrowserRouter,
-	BrowserRouter as Router,
-	Route,
-	Switch
-} from 'react-router-dom';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import Main from './page/main';
+import Detail from './page/detail';
 
 const globalStyle = css`
 	* {
@@ -33,7 +29,8 @@ const App = () => {
 			<Gnb />
 			<Router>
 				<Switch>
-					<Route path="/" component={Main} />
+					<Route exact path="/" component={Main} />
+					<Route path="/post/:postId" component={Detail} />
 				</Switch>
 			</Router>
 		</>

--- a/client/src/common/post-list/component/Item.tsx
+++ b/client/src/common/post-list/component/Item.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { css } from '@emotion/react';
+import styled from '@emotion/styled';
 import GroupIcon from '@mui/icons-material/Group';
 import { ItemType } from '../../../type';
 import { dateFormat } from '../../../util/util';
 import { Chip } from '@mui/material';
+import { Link } from 'react-router-dom';
 
 const ItemStyle = css`
 	margin: 3px 0;
@@ -33,16 +35,30 @@ const DescStyle = css`
 	margin: 7px 0;
 `;
 
+const StyledLink = css`
+	text-decoration: none;
+	&:focus,
+	&:hover,
+	&:visited,
+	&:link,
+	&:active {
+		text-decoration: none;
+		color: black;
+	}
+`;
+
 export default function Item(props: { item: ItemType }) {
 	return (
 		<li css={ItemStyle}>
-			<div css={TopicStyle}>{props.item.title}</div>
-			<div css={DescStyle}>
-				<GroupIcon sx={{ fontSize: 16 }} />
-				{props.item.participantCnt}/{props.item.capacity} |{' '}
-				{dateFormat(props.item.deadline)}까지
-			</div>
-			<Chip label={props.item.category} sx={{ color: 'grey' }} />
+			<Link to={`/post/${props.item.id}`} css={StyledLink}>
+				<div css={TopicStyle}>{props.item.title}</div>
+				<div css={DescStyle}>
+					<GroupIcon sx={{ fontSize: 16 }} />
+					{props.item.participantCnt}/{props.item.capacity} |{' '}
+					{dateFormat(props.item.deadline)}까지
+				</div>
+				<Chip label={props.item.category} sx={{ color: 'grey' }} />
+			</Link>
 		</li>
 	);
 }

--- a/client/src/page/detail/index.tsx
+++ b/client/src/page/detail/index.tsx
@@ -1,1 +1,118 @@
-export {};
+import React from 'react';
+import {
+	Card,
+	CardContent,
+	Typography,
+	Button,
+	IconButton
+} from '@mui/material';
+import { grey } from '@mui/material/colors';
+import Box from '@mui/material/Box';
+import styled from '@emotion/styled';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import { Chip } from '@mui/material';
+
+const StyledBox = styled(Box)(() => ({
+	backgroundColor: '#ffe7e7',
+	border: '1px solid #fefafa'
+}));
+const Puller = styled(Box)(() => ({
+	width: 30,
+	height: 6,
+	backgroundColor: grey[900],
+	borderRadius: 3,
+	position: 'absolute',
+	top: 8,
+	left: 'calc(50% - 15px)'
+}));
+export default function Detail() {
+	return (
+		<div>
+			<Card
+				sx={{
+					minWidth: 275,
+					mr: '10px',
+					ml: '10px',
+					mt: '5.5rem',
+					borderRadius: 7,
+					bgcolor: '#fefafa',
+					border: '1px solid #fefafa'
+				}}
+				variant="outlined"
+			>
+				<CardContent>
+					<Box
+						sx={{
+							display: 'flex',
+							justifyContent: 'space-between'
+						}}
+					>
+						<Typography variant="h5">Word of the Day</Typography>
+						<Chip label={'해외배송'} sx={{ color: 'grey' }} />
+					</Box>
+					<Box
+						sx={{
+							display: 'flex',
+							justifyContent: 'space-between',
+							mt: 2
+						}}
+					>
+						<Typography variant="body1">
+							작성자| {111111}
+						</Typography>
+						<Typography variant="body2">
+							마감시간| 11 : 00
+						</Typography>
+					</Box>
+					<Card
+						sx={{
+							mt: 2,
+							minWidth: 275,
+							minHeight: 275,
+							bgcolor: '#ffe7e7',
+							border: '1px solid #fefafa',
+							borderRadius: 7
+						}}
+						variant="outlined"
+					>
+						<CardContent>
+							<Typography variant="body2">
+								Word of the Day
+							</Typography>
+						</CardContent>
+					</Card>
+				</CardContent>
+			</Card>
+
+			<StyledBox
+				sx={{
+					position: 'fixed',
+					bottom: 0,
+					borderTopLeftRadius: 30,
+					borderTopRightRadius: 30,
+					visibility: 'visible',
+					right: 0,
+					left: 0,
+					height: '4.5rem'
+				}}
+			>
+				<Box sx={{ display: 'flex', p: 1 }}>
+					<IconButton sx={{ bgcolor: 'white', p: 1, m: 1 }}>
+						<FavoriteBorderIcon sx={{ fontSize: 30 }} />
+					</IconButton>
+					<Button
+						variant="contained"
+						sx={{
+							bgcolor: '#F76A6A',
+							flexGrow: 1,
+							p: 1,
+							m: 1
+						}}
+					>
+						공동 구매
+					</Button>
+				</Box>
+			</StyledBox>
+		</div>
+	);
+}


### PR DESCRIPTION
### 작업 목록
- react-router-dom의 Route와 Link를 이용해 게시글 상세 페이지로 라우팅 구현
- MUI를 사용해 게시글 상세 페이지 초기 UI 레이아웃 설계
### 고민
북마크 어떻게 구현할지 생각 중.. 
### 상세 페이지 디자인 피드백 요청
![image](https://user-images.githubusercontent.com/67548567/140863578-929e83b5-6bdc-47d6-be46-2dc1595d0b35.png)
