### PR TITLE
fix[#123] : 메인 페이지 게시글 Description 잘림 현상 해결 - close #123

### DIFF
--- a/client/src/common/post-list/component/Item.tsx
+++ b/client/src/common/post-list/component/Item.tsx
@@ -49,11 +49,18 @@ const ItemDeadlineStyle = css`
 `;
 
 const ItemDescStyle = css`
-	font-size: 9px;
+	--font-size: 9px;
+	--line-height: 1.4;
+	--lines-to-show: 2;
+	font-size: var(--font-size);
 	text-overflow: ellipsis;
-	height: 30px;
+	height: calc(var(--font-size) * var(--line-height) * var(--lines-to-show));
+	line-height: var(--line-height);
 	margin: 5px 0;
 	overflow: hidden;
+	display: -webkit-box;
+	-webkit-line-clamp: var(--lines-to-show);
+	-webkit-box-orient: vertical;
 	color: #404040;
 `;
 


### PR DESCRIPTION
## 해결한 내용

- 최대 두 줄만 Description을 출력하고 나머지는 '...' 처리하도록 구현하였습니다.
- Merge하기 전 **다양한 기기에서 충분한 테스트가 필요합니다.**

## 스크린샷

<img src="https://user-images.githubusercontent.com/76616101/141317554-0d019890-102b-4125-983d-02fc5672bfb2.png" width="400" />
