### PR TITLE
feat[#137] : 채팅 페이지 참여자 리스트 개선

### DIFF
--- a/client/src/asset/crown.svg
+++ b/client/src/asset/crown.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+ xmlns:svg="http://www.w3.org/2000/svg"
+ xmlns="http://www.w3.org/2000/svg"
+ version="1.0"
+ width="128"
+ height="128">
+ <g><path
+ d="m 64.000012,31.484944 28.902346,36.127871 28.902242,-36.127871 -7.22553,65.030147 -101.158086,0 L 6.1954237,31.484944 35.0977,67.612815 64.000012,31.484944 z"
+ style="fill:#ffcd00;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:4.33534527;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" /></g></svg>

--- a/client/src/page/chat/component/UserList.tsx
+++ b/client/src/page/chat/component/UserList.tsx
@@ -1,30 +1,37 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import { MonetizationOn } from '@mui/icons-material';
+import crown from '../../../asset/crown.svg';
+import { Button } from '@mui/material';
 
 const DUMMYUSERS = [
 	// REMOVE LATER
 	{
+		id: 1024025,
 		name: 'Linus Torvalds',
 		img: 'https://avatars.githubusercontent.com/u/1024025?v=4',
 		point: 30000
 	},
 	{
+		id: 53253189,
 		name: 'FloralLife',
 		img: 'https://avatars.githubusercontent.com/u/53253189?v=4',
 		point: 30000
 	},
 	{
+		id: 67548567,
 		name: 'J127_우재석',
 		img: 'https://avatars.githubusercontent.com/u/67548567?v=4',
 		point: null
 	},
 	{
+		id: 76616101,
 		name: 'gintooooonic',
 		img: 'https://avatars.githubusercontent.com/u/76616101?v=4',
 		point: 50000
 	},
 	{
+		id: 80206884,
 		name: 'J119_안병웅',
 		img: 'https://avatars.githubusercontent.com/u/80206884?v=4',
 		point: null
@@ -49,17 +56,31 @@ const UserListItemStyle = css`
 	display: flex;
 	align-items: center;
 	margin: 15px 0;
+	position: relative;
+`;
+
+const UserHostCrownStyle = css`
+	width: 20px;
+	position: absolute;
+	left: 2px;
+	top: -13px;
+`;
+
+const UserKickBtnStyle = css`
+	font-size: 10px;
+	color: #f76a6a;
+	background-color: rgba(0, 0, 0, 0);
+	border: 0;
 `;
 
 const UserAvatarStyle = css`
 	width: 25px;
 	height: 25px;
-	margin-right: 5px;
 	border-radius: 50%;
 `;
 
 const UserNameStyle = css`
-	margin: 0;
+	margin: 0 7px;
 	font-size: 14px;
 `;
 
@@ -85,10 +106,18 @@ export function UserList() {
 }
 
 function UserListItem(props: { user: any }) {
+	const hostId = 53253189; // REMOVE LATER
+	const loginId = 53253189; // REMOVE LATER
 	return (
 		<li css={UserListItemStyle}>
+			{hostId === props.user.id && (
+				<img src={crown} css={UserHostCrownStyle} />
+			)}
 			<img src={props.user.img} css={UserAvatarStyle} />
 			<p css={UserNameStyle}>{props.user.name}</p>
+			{hostId === loginId && (
+				<button css={UserKickBtnStyle}>내보내기</button>
+			)}
 			{props.user.point && (
 				<div css={UserPointStyle}>
 					<MonetizationOn />

--- a/client/src/page/chat/component/UserList.tsx
+++ b/client/src/page/chat/component/UserList.tsx
@@ -1,8 +1,15 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { css } from '@emotion/react';
 import { MonetizationOn } from '@mui/icons-material';
 import crown from '../../../asset/crown.svg';
-import { Button } from '@mui/material';
+import {
+	Button,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogContentText,
+	DialogTitle
+} from '@mui/material';
 
 const DUMMYUSERS = [
 	// REMOVE LATER
@@ -104,10 +111,14 @@ export function UserList() {
 		</div>
 	);
 }
-
 function UserListItem(props: { user: any }) {
 	const hostId = 53253189; // REMOVE LATER
 	const loginId = 53253189; // REMOVE LATER
+
+	const [isDialogOn, setIsDialogOn] = useState(false);
+	const handleDialogOpen = () => setIsDialogOn(true);
+	const handleDialogClose = () => setIsDialogOn(false);
+
 	return (
 		<li css={UserListItemStyle}>
 			{hostId === props.user.id && (
@@ -116,7 +127,9 @@ function UserListItem(props: { user: any }) {
 			<img src={props.user.img} css={UserAvatarStyle} />
 			<p css={UserNameStyle}>{props.user.name}</p>
 			{hostId === loginId && (
-				<button css={UserKickBtnStyle}>내보내기</button>
+				<button css={UserKickBtnStyle} onClick={handleDialogOpen}>
+					내보내기
+				</button>
 			)}
 			{props.user.point && (
 				<div css={UserPointStyle}>
@@ -124,6 +137,25 @@ function UserListItem(props: { user: any }) {
 					<p>{props.user.point}</p>
 				</div>
 			)}
+			<Dialog
+				open={isDialogOn}
+				onClose={handleDialogClose}
+				aria-labelledby="alert-dialog-title"
+				aria-describedby="alert-dialog-description"
+			>
+				<DialogTitle>사용자 내보내기</DialogTitle>
+				<DialogContent>
+					<DialogContentText id="alert-dialog-description">
+						정말 사용자를 채팅방에서 내보내시겠습니까?
+					</DialogContentText>
+				</DialogContent>
+				<DialogActions>
+					<Button onClick={handleDialogClose}>취소</Button>
+					<Button onClick={handleDialogClose} autoFocus>
+						내보내기
+					</Button>
+				</DialogActions>
+			</Dialog>
 		</li>
 	);
 }


### PR DESCRIPTION
- 호스트 사용자의 프로필 사진 위에 왕관 아이콘을 출력
- 호스트에게만 보이는 내보내기 버튼 추가
- 내보내기 버튼 클릭시 Confirm 모달 출력

<img src="https://user-images.githubusercontent.com/76616101/141799509-a2975628-6efb-4fe0-9f62-a41252639ff8.png" width="400" />
