### PR TITLE
feat[#148] : 채팅 참여자 리스트 서버 연동 작업

### DIFF
--- a/client/src/common/confirm/index.tsx
+++ b/client/src/common/confirm/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import {
+	Button,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogContentText,
+	DialogTitle
+} from '@mui/material';
+
+type ConfirmParamType = {
+	on: boolean;
+	title: string;
+	children: React.ReactNode;
+	onCancel: Function;
+	onConfirm: Function;
+};
+
+export default function Confirm(props: ConfirmParamType) {
+	return (
+		<Dialog
+			open={props.on}
+			onClose={() => props.onCancel()}
+			aria-labelledby="alert-dialog-title"
+			aria-describedby="alert-dialog-description"
+		>
+			<DialogTitle>{props.title}</DialogTitle>
+			<DialogContent>
+				<DialogContentText id="alert-dialog-description">
+					{props.children}
+				</DialogContentText>
+			</DialogContent>
+			<DialogActions>
+				<Button onClick={() => props.onCancel()}>취소</Button>
+				<Button onClick={() => props.onConfirm()} autoFocus>
+					확인
+				</Button>
+			</DialogActions>
+		</Dialog>
+	);
+}

--- a/client/src/page/chat/component/UserList.tsx
+++ b/client/src/page/chat/component/UserList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import { MonetizationOn } from '@mui/icons-material';
 import crown from '../../../asset/crown.svg';
@@ -10,40 +10,8 @@ import {
 	DialogContentText,
 	DialogTitle
 } from '@mui/material';
-
-const DUMMYUSERS = [
-	// REMOVE LATER
-	{
-		id: 1024025,
-		name: 'Linus Torvalds',
-		img: 'https://avatars.githubusercontent.com/u/1024025?v=4',
-		point: 30000
-	},
-	{
-		id: 53253189,
-		name: 'FloralLife',
-		img: 'https://avatars.githubusercontent.com/u/53253189?v=4',
-		point: 30000
-	},
-	{
-		id: 67548567,
-		name: 'J127_우재석',
-		img: 'https://avatars.githubusercontent.com/u/67548567?v=4',
-		point: null
-	},
-	{
-		id: 76616101,
-		name: 'gintooooonic',
-		img: 'https://avatars.githubusercontent.com/u/76616101?v=4',
-		point: 50000
-	},
-	{
-		id: 80206884,
-		name: 'J119_안병웅',
-		img: 'https://avatars.githubusercontent.com/u/80206884?v=4',
-		point: null
-	}
-];
+import { fetchGet } from '../../../util/util';
+import 'dotenv/config';
 
 const UserListStyle = css`
 	padding: 0 15px;
@@ -99,19 +67,40 @@ const UserPointStyle = css`
 	}
 `;
 
+type ParticipantType = {
+	point: number;
+	user: {
+		id: number;
+		name: string;
+		img: string;
+	};
+};
+
 export function UserList() {
+	const [participants, setParticipants] = useState<ParticipantType[]>([]);
+	const updateParticipants = async (postId: number) => {
+		const url = `${process.env.REACT_APP_SERVER_URL}/api/chat/${postId}/participant`;
+		const result = await fetchGet(url);
+		setParticipants(result);
+	};
+
+	useEffect(() => {
+		const DUMMYPOSTID = 1000026;
+		updateParticipants(DUMMYPOSTID);
+	}, []);
+
 	return (
 		<div css={UserListStyle}>
-			<h1>참여자 ({DUMMYUSERS.length}명)</h1>
+			<h1>참여자 ({participants.length}명)</h1>
 			<ul>
-				{DUMMYUSERS.map(user => (
-					<UserListItem user={user} />
+				{participants.map(user => (
+					<UserListItem key={user.user.id} user={user} />
 				))}
 			</ul>
 		</div>
 	);
 }
-function UserListItem(props: { user: any }) {
+function UserListItem({ user }: { user: ParticipantType }) {
 	const hostId = 53253189; // REMOVE LATER
 	const loginId = 53253189; // REMOVE LATER
 
@@ -121,20 +110,20 @@ function UserListItem(props: { user: any }) {
 
 	return (
 		<li css={UserListItemStyle}>
-			{hostId === props.user.id && (
+			{hostId === user.user.id && (
 				<img src={crown} css={UserHostCrownStyle} />
 			)}
-			<img src={props.user.img} css={UserAvatarStyle} />
-			<p css={UserNameStyle}>{props.user.name}</p>
+			<img src={user.user.img} css={UserAvatarStyle} />
+			<p css={UserNameStyle}>{user.user.name}</p>
 			{hostId === loginId && (
 				<button css={UserKickBtnStyle} onClick={handleDialogOpen}>
 					내보내기
 				</button>
 			)}
-			{props.user.point && (
+			{user.point && (
 				<div css={UserPointStyle}>
 					<MonetizationOn />
-					<p>{props.user.point}</p>
+					<p>{user.point}</p>
 				</div>
 			)}
 			<Dialog

--- a/client/src/page/chat/component/UserList.tsx
+++ b/client/src/page/chat/component/UserList.tsx
@@ -2,16 +2,9 @@ import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import { MonetizationOn } from '@mui/icons-material';
 import crown from '../../../asset/crown.svg';
-import {
-	Button,
-	Dialog,
-	DialogActions,
-	DialogContent,
-	DialogContentText,
-	DialogTitle
-} from '@mui/material';
 import { fetchGet } from '../../../util/util';
 import 'dotenv/config';
+import Confirm from '../../../common/confirm';
 
 const UserListStyle = css`
 	padding: 0 15px;
@@ -104,9 +97,7 @@ function UserListItem({ user }: { user: ParticipantType }) {
 	const hostId = 53253189; // REMOVE LATER
 	const loginId = 53253189; // REMOVE LATER
 
-	const [isDialogOn, setIsDialogOn] = useState(false);
-	const handleDialogOpen = () => setIsDialogOn(true);
-	const handleDialogClose = () => setIsDialogOn(false);
+	const [isConfirmOn, setIsConfirmOn] = useState(false);
 
 	return (
 		<li css={UserListItemStyle}>
@@ -116,7 +107,10 @@ function UserListItem({ user }: { user: ParticipantType }) {
 			<img src={user.user.img} css={UserAvatarStyle} />
 			<p css={UserNameStyle}>{user.user.name}</p>
 			{hostId === loginId && (
-				<button css={UserKickBtnStyle} onClick={handleDialogOpen}>
+				<button
+					css={UserKickBtnStyle}
+					onClick={() => setIsConfirmOn(true)}
+				>
 					내보내기
 				</button>
 			)}
@@ -126,25 +120,14 @@ function UserListItem({ user }: { user: ParticipantType }) {
 					<p>{user.point}</p>
 				</div>
 			)}
-			<Dialog
-				open={isDialogOn}
-				onClose={handleDialogClose}
-				aria-labelledby="alert-dialog-title"
-				aria-describedby="alert-dialog-description"
+			<Confirm
+				on={isConfirmOn}
+				title="사용자 내보내기"
+				onCancel={() => setIsConfirmOn(false)}
+				onConfirm={() => setIsConfirmOn(false)}
 			>
-				<DialogTitle>사용자 내보내기</DialogTitle>
-				<DialogContent>
-					<DialogContentText id="alert-dialog-description">
-						정말 사용자를 채팅방에서 내보내시겠습니까?
-					</DialogContentText>
-				</DialogContent>
-				<DialogActions>
-					<Button onClick={handleDialogClose}>취소</Button>
-					<Button onClick={handleDialogClose} autoFocus>
-						내보내기
-					</Button>
-				</DialogActions>
-			</Dialog>
+				정말 사용자를 채팅에서 내보내시겠습니까?
+			</Confirm>
 		</li>
 	);
 }

--- a/client/src/page/chat/component/UserList.tsx
+++ b/client/src/page/chat/component/UserList.tsx
@@ -70,6 +70,13 @@ type ParticipantType = {
 };
 
 export function UserList() {
+	const [myId, setMyId] = useState<number>(-1);
+	const updateMyId = async () => {
+		const url = `${process.env.REACT_APP_SERVER_URL}/api/login`;
+		const result = await fetchGet(url);
+		if (!isNaN(+result)) setMyId(+result); // note: result can be "jwt expired" or other string value
+	};
+
 	const [participants, setParticipants] = useState<ParticipantType[]>([]);
 	const updateParticipants = async (postId: number) => {
 		const url = `${process.env.REACT_APP_SERVER_URL}/api/chat/${postId}/participant`;
@@ -80,6 +87,7 @@ export function UserList() {
 	useEffect(() => {
 		const DUMMYPOSTID = 1000026;
 		updateParticipants(DUMMYPOSTID);
+		updateMyId();
 	}, []);
 
 	return (
@@ -87,15 +95,14 @@ export function UserList() {
 			<h1>참여자 ({participants.length}명)</h1>
 			<ul>
 				{participants.map(user => (
-					<UserListItem key={user.user.id} user={user} />
+					<UserListItem key={user.user.id} user={user} myId={myId} />
 				))}
 			</ul>
 		</div>
 	);
 }
-function UserListItem({ user }: { user: ParticipantType }) {
-	const hostId = 53253189; // REMOVE LATER
-	const loginId = 53253189; // REMOVE LATER
+function UserListItem({ user, myId }: { user: ParticipantType; myId: number }) {
+	const hostId = 76616101; // should be replaced by real host id
 
 	const [isConfirmOn, setIsConfirmOn] = useState(false);
 
@@ -106,7 +113,7 @@ function UserListItem({ user }: { user: ParticipantType }) {
 			)}
 			<img src={user.user.img} css={UserAvatarStyle} />
 			<p css={UserNameStyle}>{user.user.name}</p>
-			{hostId === loginId && (
+			{hostId === myId && (
 				<button
 					css={UserKickBtnStyle}
 					onClick={() => setIsConfirmOn(true)}

--- a/server/controller/participant-controller.ts
+++ b/server/controller/participant-controller.ts
@@ -2,6 +2,21 @@ import { Request, Response } from 'express';
 import participantService from '../service/participant-service';
 import postService from '../service/post-service';
 
+export const getParticipants = async (
+	req: Request,
+	res: Response,
+	next: Function
+) => {
+	try {
+		const participants = await participantService.getParticipants(
+			+req.params.post_id
+		);
+		res.json(participants);
+	} catch (err: any) {
+		next({ statusCode: 500, message: err.message });
+	}
+};
+
 export const createParticipant = async (
 	req: Request,
 	res: Response,

--- a/server/routes/chat.ts
+++ b/server/routes/chat.ts
@@ -1,7 +1,11 @@
 import express from 'express';
-import { createParticipant } from '../controller/participant-controller';
+import {
+	getParticipants,
+	createParticipant
+} from '../controller/participant-controller';
 
 const router = express.Router();
+router.get('/:post_id/participant', getParticipants);
 router.post('/:post_id/participant', createParticipant);
 
 const errorHandler = (err: any, req: any, res: any, next: any) => {

--- a/server/service/participant-service.ts
+++ b/server/service/participant-service.ts
@@ -9,6 +9,15 @@ const getParticipantNum = async (postId: number) => {
 	return result;
 };
 
+const getParticipants = async (postId: number) => {
+	const db = await getDB().get();
+	const result = await db.manager.find(Participant, {
+		where: { postId },
+		relations: ['user']
+	});
+	return result;
+};
+
 const saveParticipant = async (userId: number, postId: number) => {
 	const db = await getDB().get();
 
@@ -21,4 +30,4 @@ const saveParticipant = async (userId: number, postId: number) => {
 	return createdParticipant;
 };
 
-export default { getParticipantNum, saveParticipant };
+export default { getParticipantNum, getParticipants, saveParticipant };


### PR DESCRIPTION
- 참여자 리스트를 반환하는 API를 구현하였습니다. `GET /api/chat/:postId/participant`
- 채팅 페이지 메뉴의 `UserList` 컴포넌트에서 참여자 리스트를 서버에 요청하고, 받아온 정보를 출력합니다.
  - 현재 게시글의 `postId`를 받아오지 못해 임의의 값을 사용하고 있습니다.
- 현재 로그인 되어 있는 아이디가 게시글의 호스트 아이디와 같은지 비교하여, 같다면 호스트 전용 레이아웃(내보내기 버튼 등)을 출력합니다.
  - 현재 게시글의 호스트 아이디를 받아오지 못해 임의의 값을 사용하고 있습니다.
- 사용자 내보내기 버튼 클릭시 띄우던 MUI의 Dialog 컴포넌트를 래핑하여 common 컴포넌트로 구현하였습니다. `src/common/confirm` 참고.