### PR TITLE
fix[#119] : 현재 위치 관련 버그 해결

### DIFF
--- a/client/src/common/search-modal/component/NaverMapAPI.tsx
+++ b/client/src/common/search-modal/component/NaverMapAPI.tsx
@@ -41,7 +41,7 @@ function NaverMapAPI({ setIsMapOn, setLocation, location }: mapState) {
 		const initMap = () => {
 			map = new naver.maps.Map('map', {
 				center: new naver.maps.LatLng(location.lat, location.lng),
-				zoom: 13
+				zoom: 16
 			});
 		};
 		initMap();

--- a/client/src/common/search-modal/index.tsx
+++ b/client/src/common/search-modal/index.tsx
@@ -155,7 +155,9 @@ function SearchModal({
 					});
 					return arr;
 				});
-				setLocation({ lat: query.lat, lng: query.long });
+				if (query.lat && query.long) {
+					setLocation({ lat: query.lat, lng: query.long });
+				}
 				if (query.search) setSearch(query.search);
 				setCheckedFinished(checkedFinished => {
 					if (query.finished === true) checkedFinished[1] = true;

--- a/client/src/page/main/index.tsx
+++ b/client/src/page/main/index.tsx
@@ -14,6 +14,8 @@ import noItemImg from '../../asset/noitem.png';
 import { CircularProgress, Box } from '@mui/material';
 import { createTheme, ThemeProvider } from '@mui/system';
 import { Link, Redirect } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import { locationState } from '../../store/location';
 
 const theme = createTheme({
 	palette: {
@@ -41,6 +43,7 @@ function Main() {
 	const [items, setItems] = useState<ItemType[]>([]);
 	const [alert, setAlert] = useState(false);
 	const [isFetch, setIsFetch] = useState(false);
+	const location = useRecoilValue(locationState);
 
 	let offset = useRef(0);
 	const loader = useRef(null);
@@ -48,7 +51,7 @@ function Main() {
 	useEffect(() => {
 		setItems([]);
 		offset.current = 0;
-	}, [window.location.search]);
+	}, [window.location.search, location]);
 
 	const handleObserver = useCallback(
 		entry => {
@@ -61,6 +64,8 @@ function Main() {
 					createQueryString({
 						offset: offset.current,
 						limit: 15,
+						lat: location.lat,
+						long: location.lng,
 						...filter
 					})
 				)
@@ -75,7 +80,7 @@ function Main() {
 					});
 			}
 		},
-		[window.location.search]
+		[window.location.search, location]
 	);
 
 	useEffect(() => {

--- a/client/src/type/index.ts
+++ b/client/src/type/index.ts
@@ -19,7 +19,7 @@ export interface QueryStringType {
 	limit?: number;
 	category?: number[];
 	finished?: boolean | undefined;
-	lat: number;
-	long: number;
+	lat?: number;
+	long?: number;
 	search?: string;
 }

--- a/client/src/util/util.ts
+++ b/client/src/util/util.ts
@@ -66,11 +66,7 @@ export const dateFormat = (dateStr: string) => {
 };
 
 export const decomposeQueryString = (queryStr: string) => {
-	const DEFAULT_LOCATION = {
-		lat: 37.5642135,
-		long: 127.0016985
-	};
-	const result: QueryStringType = DEFAULT_LOCATION;
+	const result: QueryStringType = {};
 	const params = new URLSearchParams(queryStr);
 	result.category = params
 		.get('category')
@@ -80,8 +76,8 @@ export const decomposeQueryString = (queryStr: string) => {
 	result.finished = params.get('finished')
 		? params.get('finished') === 'true'
 		: undefined;
-	result.lat = Number(params.get('lat') ?? DEFAULT_LOCATION.lat);
-	result.long = Number(params.get('long') ?? DEFAULT_LOCATION.long);
+	if (Number(params.get('lat'))) result.lat = Number(params.get('lat'));
+	if (Number(params.get('long'))) result.long = Number(params.get('long'));
 	result.search = params.get('search')
 		? params.get('search') + ''
 		: undefined;


### PR DESCRIPTION
## Problem

- 정상적으로 현재 위치를 가져오지만, 가져온 위치가 메인 페이지 게시글과 서치 모달에 반영되지 않음

## Solution

- 현재 위치 상태(Recoil)가 변하면 메인 페이지의 게시글을 다시 로드하도록 수정
- decomposeQueryString 수정
  - 기존에는 쿼리스트링에 위도와 경도 값이 없으면 디폴트 값을 넣어 반환하였음.
  - 변경된 코드에서는 쿼리스트링에 위도와 경도 값이 없으면 반환값에 위도와 경도가 아예 포함되지 않음.
- QueryStringType 수정
  - lat과 long을 필수 항목이 아닌 선택 항목으로 변경

정리하면, 다음과 같이 동작합니다.
1. 쿼리스트링에 lat과 long이 있다면, 해당 위치 기준으로 게시글을 로드합니다.
2. 쿼리스트링에 lat과 long이 없다면, locationState(Recoil 상태)에 저장된 위도와 경도 기준으로 게시글을 로드합니다.