### PR TITLE
linkPreview-controller 리팩토링

### DIFF
--- a/server/type/index.ts
+++ b/server/type/index.ts
@@ -23,18 +23,18 @@ export type TokenType = {
 	id: number;
 };
 
-export interface APIOutput {
+export type APIOutput = {
 	title: string | null;
 	description: string | null;
 	image: string | null;
 	siteName: string | null;
 	hostname: string | null;
-}
-interface Image {
+};
+type Image = {
 	url: string;
-}
+};
 
-export interface MetaResult {
+export type MetaResult = {
 	images: Array<Image>;
 	meta: {
 		description?: string;
@@ -50,4 +50,4 @@ export interface MetaResult {
 		url?: string;
 		videos?: Array<Image>;
 	};
-}
+};


### PR DESCRIPTION
- 오류 처리 일관성 유지
- 삼항 연산자 중복 사용을 함수 로직으로 분리
- 타입 선언을 interface에서 type으로 변경