### PR TITLE
채팅 메뉴 켰을 때 현재 구매 상태에 따라 다르게 표시

### DIFF
--- a/client/src/page/chat/component/ChatBar.tsx
+++ b/client/src/page/chat/component/ChatBar.tsx
@@ -24,8 +24,6 @@ const TitleStyle = css`
 type propsType = {
 	title: string;
 	socket: Socket;
-	postId: string;
-	userId: string;
 };
 
 function ChatBar(props: propsType) {
@@ -41,11 +39,7 @@ function ChatBar(props: propsType) {
 				}}
 			/>
 			<div css={TitleStyle}>{props.title}</div>
-			<ChatMenuDrawer
-				socket={props.socket}
-				postId={props.postId}
-				userId={props.userId}
-			/>
+			<ChatMenuDrawer socket={props.socket} />
 		</div>
 	);
 }

--- a/client/src/page/chat/component/ChatMenu.tsx
+++ b/client/src/page/chat/component/ChatMenu.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@emotion/react';
 import { Close } from '@mui/icons-material';
 import { UserList } from './UserList';
-import { PointView } from './PointView';
+import PointView from './PointView';
 import { Button } from '@mui/material';
 import { Socket } from 'socket.io-client';
 
@@ -41,8 +41,6 @@ const QuitBtnStyle = css`
 type propsType = {
 	onCloseBtnClicked: Function;
 	socket: Socket;
-	postId: string;
-	userId: string;
 };
 
 export function ChatMenu(props: propsType) {
@@ -53,12 +51,7 @@ export function ChatMenu(props: propsType) {
 				onClick={() => props.onCloseBtnClicked()}
 			/>
 			<UserList />
-			<PointView
-				socket={props.socket}
-				point={null}
-				postId={props.postId}
-				userId={props.userId}
-			/>
+			<PointView socket={props.socket} />
 			<div css={QuitBtnContainerStyle}>
 				<Button css={QuitBtnStyle}>나가기</Button>
 			</div>

--- a/client/src/page/chat/component/ChatMenuDrawer.tsx
+++ b/client/src/page/chat/component/ChatMenuDrawer.tsx
@@ -17,8 +17,6 @@ const BlurredBackground = css`
 
 type propsType = {
 	socket: Socket;
-	postId: string;
-	userId: string;
 };
 
 export function ChatMenuDrawer(props: propsType) {
@@ -47,8 +45,6 @@ export function ChatMenuDrawer(props: propsType) {
 				<ChatMenu
 					onCloseBtnClicked={() => setIsMenuOn(false)}
 					socket={props.socket}
-					postId={props.postId}
-					userId={props.userId}
 				/>
 			</SwipeableDrawer>
 		</>

--- a/client/src/page/chat/index.tsx
+++ b/client/src/page/chat/index.tsx
@@ -75,8 +75,6 @@ function Chat(props: any) {
 			<ChatBar
 				title={'타이틀이 들어갈 공간입니당아아아'}
 				socket={socketRef.current}
-				postId={postId}
-				userId={userId}
 			/>
 			<div css={ChatLayout}>
 				{chatDatas.map((chat: MessageType) => {

--- a/client/src/util/util.ts
+++ b/client/src/util/util.ts
@@ -92,3 +92,7 @@ export const getCurrentTime = () => {
 	currentHour = currentHour < 12 ? currentHour : currentHour - 12;
 	return strAmPm + currentHour + '시 ' + currentMinutes + '분';
 };
+
+export const parsePath = (pathName: string): string[] => {
+	return pathName.split('/').filter(path => path !== '');
+};

--- a/server/controller/login-controller.ts
+++ b/server/controller/login-controller.ts
@@ -24,7 +24,7 @@ export const checkLogin = async (
 	try {
 		const { id } = verifyToken(req.cookies.user) as TokenType;
 		if (id) {
-			const user = await userService.findById(String(id));
+			const user = await userService.findById(id);
 			if (user) res.status(200).json(id);
 			else next({ statusCode: 401, message: 'unauthorized' });
 		} else next({ statusCode: 401, message: 'unauthorized' });

--- a/server/controller/participant-controller.ts
+++ b/server/controller/participant-controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import participantService from '../service/participant-service';
 import postService from '../service/post-service';
+import userService from '../service/user-service';
 
 export const getParticipants = async (
 	req: Request,
@@ -38,6 +39,31 @@ export const createParticipant = async (
 			req.body.postId
 		);
 		res.json(createdParticipant);
+	} catch (err: any) {
+		next({ statusCode: 500, message: err.message });
+	}
+};
+
+export const getParticipantPoint = async (
+	req: Request,
+	res: Response,
+	next: Function
+) => {
+	try {
+		const participant = participantService.getParticipant(
+			+req.params.post_id,
+			+req.params.user_id
+		);
+		const user = userService.findById(+req.params.user_id);
+		Promise.all([participant, user]).then(result => {
+			if (!result.includes(undefined)) {
+				res.json({
+					purchasePoint: result[0]?.point,
+					leftPoint: result[1]?.point
+				});
+			} else
+				next({ statusCode: 500, message: '사용자 정보 불러오기 실패' });
+		});
 	} catch (err: any) {
 		next({ statusCode: 500, message: err.message });
 	}

--- a/server/routes/chat.ts
+++ b/server/routes/chat.ts
@@ -1,12 +1,14 @@
 import express from 'express';
 import {
 	getParticipants,
-	createParticipant
+	createParticipant,
+	getParticipantPoint
 } from '../controller/participant-controller';
 
 const router = express.Router();
 router.get('/:post_id/participant', getParticipants);
 router.post('/:post_id/participant', createParticipant);
+router.get('/:post_id/participant/:user_id', getParticipantPoint);
 
 const errorHandler = (err: any, req: any, res: any, next: any) => {
 	res.status(err.statusCode).json(err.message);

--- a/server/service/user-service.ts
+++ b/server/service/user-service.ts
@@ -2,18 +2,18 @@ import { Db } from 'typeorm';
 import { getDB } from '../db/db';
 import { User } from '../model/entity/User';
 
-const findById = async (id: string): Promise<User | undefined> => {
+const findById = async (id: number): Promise<User | undefined> => {
 	const db = await getDB().get();
 	const user = await db.manager.findOne(User, {
-		where: { id: Number(id) }
+		where: { id: id }
 	});
 	return user;
 };
 
-const signUp = async (id: string): Promise<User> => {
+const signUp = async (id: number): Promise<User> => {
 	const db = await getDB().get();
 	const newUser = db.manager.create(User, {
-		id: Number(id),
+		id: id,
 		name: `horong`,
 		img: `https://user-images.githubusercontent.com/53253189/141759551-188bcdf4-5ef3-481e-959b-af124fe48a33.png`
 	});

--- a/server/socket/chat.ts
+++ b/server/socket/chat.ts
@@ -4,79 +4,71 @@ import participantService from '../service/participant-service';
 import userService from '../service/user-service';
 
 export const joinRoom = (socket: any, io: Server) => {
-	socket.on('joinRoom', (postId: string, userId: string) => {
+	socket.on('joinRoom', (postId: number, userId: number) => {
 		console.log('user: ' + userId + ' has entered room: ' + postId);
-		socket.join(postId);
+		socket.join(String(postId));
 		const joinMsg = `user ${userId} has join room ${postId}`;
-		io.to(postId).emit('afterJoin', joinMsg);
+		io.to(String(postId)).emit('afterJoin', joinMsg);
 	});
 };
 
 export const leaveRoom = (socket: any, io: Server) => {
-	socket.on('leaveRoom', (postId: string, userId: string) => {
+	socket.on('leaveRoom', (postId: number, userId: number) => {
 		console.log('user: ' + userId + ' has leaved room: ' + postId);
-		socket.leave(postId);
+		socket.leave(String(postId));
 		const leaveMsg = `user ${userId} has leaved`;
-		io.to(postId).emit('afterLeave', leaveMsg);
+		io.to(String(postId)).emit('afterLeave', leaveMsg);
 	});
 };
 
 export const sendMsg = (socket: any, io: Server) => {
-	socket.on('sendMsg', (postId: string, userId: string, msg: string) => {
+	socket.on('sendMsg', (postId: number, userId: number, msg: string) => {
 		// 채팅을 보낸 user 정보와 msg를 보내줌 => 객체로 만들어진 시간은 여기서 만들어서 보내줘야할 것 같음
-		chatService.saveChat(Number(userId), Number(postId), msg);
-		io.to(postId).emit('receiveMsg', userId, msg);
+		chatService.saveChat(userId, postId, msg);
+		io.to(String(postId)).emit('receiveMsg', userId, msg);
 	});
 };
 
 export const confirmPurchase = (socket: any, io: Server) => {
 	socket.on(
 		'point confirm',
-		async (postId: string, userId: string, sendPoint: number) => {
+		async (postId: number, userId: number, sendPoint: number) => {
 			const user = await userService.findById(userId);
 			if (user === undefined)
 				socket.emit('purchase error', '사용자 정보 에러');
 			else if (user.point < sendPoint)
 				socket.emit('purchase error', '잔여 포인트 부족');
 			else {
-				userService.usePoint(
-					Number(userId),
-					Number(user.point),
+				userService.usePoint(userId, user.point, sendPoint);
+				participantService.updatePoint(postId, userId, sendPoint);
+				io.to(String(postId)).emit(
+					'purchase confirm',
+					userId,
 					sendPoint
 				);
-				participantService.updatePoint(
-					Number(postId),
-					Number(userId),
-					sendPoint
-				);
-				io.to(postId).emit('purchase confirm', userId, sendPoint);
 			}
 		}
 	);
 };
 
 export const cancelPurchase = (socket: any, io: Server) => {
-	socket.on('point cancel', async (postId: string, userId: string) => {
+	socket.on('point cancel', async (postId: number, userId: number) => {
 		const user = await userService.findById(userId);
 		if (user === undefined)
 			socket.emit('purchase error', '사용자 정보 에러');
 		else {
 			const participant = await participantService.getParticipant(
-				Number(postId),
-				Number(userId)
+				postId,
+				userId
 			);
 			if (participant === undefined)
 				socket.emit('purchase error', '참여 정보 에러');
 			else if (participant.point === null)
 				socket.emit('purchase error', '참여 정보 없음');
 			else {
-				participantService.updatePoint(
-					Number(postId),
-					Number(userId),
-					null
-				);
-				userService.addPoint(Number(userId), participant.point);
-				io.to(postId).emit('purchase cancel', userId);
+				participantService.updatePoint(postId, userId, null);
+				userService.addPoint(userId, participant.point);
+				io.to(String(postId)).emit('purchase cancel', userId);
 			}
 		}
 	});


### PR DESCRIPTION
- 확정 상태면 포인트 수정 불가능 / 버튼은 취소 버튼
- 확정 상태가 아니면 포인트 수정 가능 / 버튼은 확정 버튼
- 확정 및 취소 버튼 누르면 소켓 이벤트 발생하고 답장이 오는데 답장이 올때까지 버튼을 비활성화 시켜놓음 (빠르게 여러번 클릭하여 중복 요청 방지)