### PR TITLE
feat[#172] : 현재 위치 정보 캐싱 및 메인 페이지에 위치 관련 인터페이스 추가

### DIFF
--- a/client/src/common/gnb/index.tsx
+++ b/client/src/common/gnb/index.tsx
@@ -63,7 +63,7 @@ function Gnb() {
 	const [location, setLocation] = useRecoilState(locationState);
 	const [isLoginModalOn, setIsLoginModalOn] = useState(false);
 	const [isAlertOn, setIsAlertOn] = useState(false);
-	const [isBackdropOn, setIsBackropOn] = useState(true);
+	const [isBackdropOn, setIsBackropOn] = useState(false);
 
 	useEffect(() => {
 		const onSuccess = (pos: any) => {
@@ -72,6 +72,8 @@ function Gnb() {
 				lng: pos.coords.longitude,
 				isLoaded: true
 			});
+			localStorage.setItem('lat', pos.coords.latitude);
+			localStorage.setItem('lng', pos.coords.longitude);
 		};
 
 		const onFailure = () => {
@@ -83,7 +85,19 @@ function Gnb() {
 			setIsAlertOn(true);
 		};
 
-		navigator.geolocation.getCurrentPosition(onSuccess, onFailure);
+		const lat = localStorage.getItem('lat');
+		const lng = localStorage.getItem('lng');
+
+		if (lat && lng) {
+			setLocation({
+				lat: +lat,
+				lng: +lng,
+				isLoaded: true
+			});
+		} else {
+			setIsBackropOn(true);
+			navigator.geolocation.getCurrentPosition(onSuccess, onFailure);
+		}
 	}, []);
 
 	useEffect(() => {

--- a/client/src/common/post-list/index.tsx
+++ b/client/src/common/post-list/index.tsx
@@ -6,7 +6,6 @@ const ListStyle = css`
 	list-style: none;
 	padding-left: 0;
 	padding: 0 15px;
-	padding-top: 20px;
 	max-width: 800px;
 	margin: 0 auto;
 `;

--- a/client/src/common/search-modal/index.tsx
+++ b/client/src/common/search-modal/index.tsx
@@ -11,7 +11,8 @@ import {
 	createQueryString,
 	decomposeQueryString,
 	fetchGet,
-	finishedToBool
+	finishedToBool,
+	getAddressByGeocode
 } from '../../util/util';
 import { LocationType } from '../../type';
 
@@ -90,20 +91,9 @@ function SearchModal({
 	const [address, setAddress] = useState('위치 확인 중');
 	const [search, setSearch] = useState('');
 
-	function searchCoordinateToAddress(latlng: any) {
-		if (naver.maps.Service) {
-			naver.maps.Service.reverseGeocode(
-				{
-					location: new naver.maps.LatLng(latlng.lat, latlng.lng)
-				},
-				function (status, response) {
-					if (status !== naver.maps.Service.Status.OK) {
-						// 에러 처리를 어떻게 해야하지?
-					}
-					setAddress(response.result.items[0].address);
-				}
-			);
-		}
+	async function searchCoordinateToAddress(latlng: any) {
+		const result = await getAddressByGeocode(latlng.lat, latlng.lng);
+		setAddress(result);
 	}
 
 	const handleCategoryClick = (idx: number) => {

--- a/client/src/page/main/component/LocationIndicator.tsx
+++ b/client/src/page/main/component/LocationIndicator.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { css } from '@emotion/react';
+import { LocationOn, Sync } from '@mui/icons-material';
+import { useRecoilValue } from 'recoil';
+import { locationState } from '../../../store/location';
+import { getAddressByGeocode } from '../../../util/util';
+
+const LocationIndicatorStyle = css`
+	display: flex;
+	align-items: center;
+	margin-left: 15px;
+`;
+
+const AddressStyle = css`
+	margin: 10px 0;
+	font-size: 12px;
+`;
+
+const ReloadStyle = css`
+	margin: 10px 5px;
+	font-size: 10px;
+	color: #f76a6a;
+`;
+
+const LocationOnIconStyle = css`
+	width: 18px;
+	height: 14px;
+	color: #f76a6a;
+`;
+
+const SyncIconStyle = css`
+	width: 24px;
+	height: 18px;
+	color: #f76a6a;
+`;
+
+export default function LocationIndicator() {
+	const location = useRecoilValue(locationState);
+	const [address, setAddress] = useState('위치 확인 중');
+
+	const updateAddress = async () => {
+		const res = await getAddressByGeocode(location.lat, location.lng);
+		setAddress(res);
+	};
+
+	useEffect(() => {
+		location.isLoaded && updateAddress();
+	}, [location.isLoaded]);
+
+	return (
+		<div css={LocationIndicatorStyle}>
+			<LocationOn css={LocationOnIconStyle} />
+			<p css={AddressStyle}>{address}</p>
+			<p css={ReloadStyle}>새로고침</p>
+		</div>
+	);
+}

--- a/client/src/page/main/index.tsx
+++ b/client/src/page/main/index.tsx
@@ -14,6 +14,7 @@ import { CircularProgress, Box } from '@mui/material';
 import { createTheme, ThemeProvider } from '@mui/system';
 import { useRecoilValue } from 'recoil';
 import { locationState } from '../../store/location';
+import LocationIndicator from './component/LocationIndicator';
 
 const theme = createTheme({
 	palette: {
@@ -97,6 +98,7 @@ function Main() {
 	return (
 		<div css={mainContainer}>
 			{alert && <ErrorAlert alert={alert} />}
+			<LocationIndicator />
 			<PostList items={items} />
 			<div ref={loader} />
 			{!isFetch && (

--- a/client/src/util/util.ts
+++ b/client/src/util/util.ts
@@ -92,3 +92,15 @@ export const getCurrentTime = () => {
 	currentHour = currentHour < 12 ? currentHour : currentHour - 12;
 	return strAmPm + currentHour + '시 ' + currentMinutes + '분';
 };
+
+export const getAddressByGeocode = (lat: number, lng: number) => {
+	return new Promise((resolve: (value: string) => void, reject) => {
+		if (!naver.maps.Service) reject('map service error');
+		const location = new naver.maps.LatLng(lat, lng);
+		naver.maps.Service.reverseGeocode({ location }, (status, response) => {
+			if (status !== naver.maps.Service.Status.OK)
+				reject('map service error');
+			resolve(response.result.items[0].address);
+		});
+	});
+};


### PR DESCRIPTION
- 현재 위치 정보를 localStorage에 캐싱합니다.
- 메인 페이지에서 다음과 같은 위치 관련 인터페이스를 제공합니다.
  - 사용자는 메인 페이지에서 현재 위치를 주소 형태로 볼 수 있습니다.
  - 사용자는 메인 페이지에서 '새로고침' 버튼을 클릭해 위치를 갱신할 수 있습니다.