### PR TITLE
feat[#184] : 채팅 메뉴에서 참여자 리스트 출력하기

### DIFF
--- a/client/src/page/chat/component/ChatMenu.tsx
+++ b/client/src/page/chat/component/ChatMenu.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import { Close } from '@mui/icons-material';
 import { UserList } from './UserList';
 import PointView from './PointView';
 import { Button } from '@mui/material';
 import { Socket } from 'socket.io-client';
+import { fetchGet, parsePath } from '../../../util/util';
 
 const ChatMenuStyle = css`
 	width: 300px;
@@ -44,13 +45,26 @@ type propsType = {
 };
 
 export function ChatMenu(props: propsType) {
+	const postId = Number(parsePath(window.location.pathname).slice(-1)[0]);
+	const [hostId, setHostId] = useState<number>(-1);
+
+	const updateHostId = async () => {
+		const url = `${process.env.REACT_APP_SERVER_URL}/api/post/${postId}/host`;
+		const result = await fetchGet(url);
+		setHostId(result);
+	};
+
+	useEffect(() => {
+		updateHostId();
+	}, []);
+
 	return (
 		<div css={ChatMenuStyle}>
 			<Close
 				css={CloseBtnStyle}
 				onClick={() => props.onCloseBtnClicked()}
 			/>
-			<UserList />
+			<UserList hostId={hostId} />
 			<PointView socket={props.socket} />
 			<div css={QuitBtnContainerStyle}>
 				<Button css={QuitBtnStyle}>나가기</Button>

--- a/client/src/page/chat/component/UserList.tsx
+++ b/client/src/page/chat/component/UserList.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import { MonetizationOn } from '@mui/icons-material';
 import crown from '../../../asset/crown.svg';
-import { fetchGet } from '../../../util/util';
+import { fetchGet, parsePath } from '../../../util/util';
 import Confirm from '../../../common/confirm';
 
 const UserListStyle = css`
@@ -69,7 +69,9 @@ type ParticipantType = {
 };
 
 export function UserList() {
-	const [myId, setMyId] = useState<number>(-1);
+	const [myId, setMyId] = useState<number>(-1); // 페이지 컴포넌트에서 가져오도록 변경
+	const postId = Number(parsePath(window.location.pathname).slice(-1)[0]);
+
 	const updateMyId = async () => {
 		const url = `${process.env.REACT_APP_SERVER_URL}/api/login`;
 		const result = await fetchGet(url);
@@ -84,8 +86,7 @@ export function UserList() {
 	};
 
 	useEffect(() => {
-		const DUMMYPOSTID = 1000026;
-		updateParticipants(DUMMYPOSTID);
+		updateParticipants(postId);
 		updateMyId();
 	}, []);
 

--- a/client/src/page/chat/component/UserList.tsx
+++ b/client/src/page/chat/component/UserList.tsx
@@ -68,7 +68,7 @@ type ParticipantType = {
 	};
 };
 
-export function UserList() {
+export function UserList({ hostId }: { hostId: number }) {
 	const [myId, setMyId] = useState<number>(-1); // 페이지 컴포넌트에서 가져오도록 변경
 	const postId = Number(parsePath(window.location.pathname).slice(-1)[0]);
 
@@ -95,15 +95,26 @@ export function UserList() {
 			<h1>참여자 ({participants.length}명)</h1>
 			<ul>
 				{participants.map(user => (
-					<UserListItem key={user.user.id} item={user} myId={myId} />
+					<UserListItem
+						key={user.user.id}
+						item={user}
+						myId={myId}
+						hostId={hostId}
+					/>
 				))}
 			</ul>
 		</div>
 	);
 }
-function UserListItem({ item, myId }: { item: ParticipantType; myId: number }) {
-	const hostId = 76616101; // should be replaced by real host id
-
+function UserListItem({
+	item,
+	myId,
+	hostId
+}: {
+	item: ParticipantType;
+	myId: number;
+	hostId: number;
+}) {
 	const [isConfirmOn, setIsConfirmOn] = useState(false);
 
 	return (

--- a/server/controller/post-controller.ts
+++ b/server/controller/post-controller.ts
@@ -45,3 +45,13 @@ export const savePost = async (req: Request, res: Response, next: Function) => {
 		next({ statusCode: 500, message: err.message });
 	}
 };
+
+export const getHost = async (req: Request, res: Response, next: Function) => {
+	try {
+		const { postId } = req.params;
+		const userId = await postService.getHost(+postId);
+		res.json(userId);
+	} catch (err: any) {
+		next({ statusCode: 500, message: err.message });
+	}
+};

--- a/server/routes/post.ts
+++ b/server/routes/post.ts
@@ -1,10 +1,16 @@
 import express, { Request, Response, Router } from 'express';
-import { getPosts, getPost, savePost } from '../controller/post-controller';
+import {
+	getPosts,
+	getPost,
+	savePost,
+	getHost
+} from '../controller/post-controller';
 
 const router = express.Router();
 router.get('/', getPosts);
 router.post('/', savePost);
 router.get('/:postId', getPost);
+router.get('/:postId/host', getHost);
 
 const errorHandler = (err: any, req: Request, res: Response, next: any) => {
 	res.status(err.statusCode).json(err.message);

--- a/server/service/post-service.ts
+++ b/server/service/post-service.ts
@@ -100,11 +100,23 @@ const getCapacity = async (postId: number) => {
 	return capacity?.capacity;
 };
 
+const getHost = async (postId: number) => {
+	const db = await getDB().get();
+	const result = await db.manager.findOne(Post, {
+		select: ['userId'],
+		where: { id: postId }
+	});
+
+	if (!result) throw new Error('post not found');
+	return result.userId;
+};
+
 export default {
 	savePost,
 	getPosts,
 	getPost,
 	updatePostFinished,
 	getCapacity,
-	saveUrls
+	saveUrls,
+	getHost
 };


### PR DESCRIPTION
- 기존에 임의의 postId로 참여자 리스트를 서버에 요청해 출력했으나, 변경된 코드로 실제 해당 채팅방의 참여자 리스트를 요청해 출력하도록 하였습니다.
- 로그인 되어 있는 사용자가 해당 게시글의 호스트인 경우, 호스트용 기능(사용자 내보내기)을 제공합니다.
- 사용자 리스트에서 호스트 사용자의 프로필 사진 위에 왕관 아이콘을 출력합니다.