### PR TITLE
feat[#192] : react-cookie 모듈사용해서 쿠키 접근

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2680,6 +2680,15 @@
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.9.tgz",
       "integrity": "sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ=="
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
@@ -12633,6 +12642,16 @@
         }
       }
     },
+    "react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      }
+    },
     "react-dev-utils": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.4.tgz",
@@ -15135,6 +15154,22 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
         "crypto-random-string": "^1.0.0"
+      }
+    },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      },
+      "dependencies": {
+        "@types/cookie": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+          "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+        }
       }
     },
     "universalify": {

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
 		"dotenv": "^10.0.0",
 		"react": "^17.0.2",
 		"react-app-rewired": "^2.1.8",
+		"react-cookie": "^4.1.1",
 		"react-dom": "^17.0.2",
 		"react-router-dom": "^5.3.0",
 		"react-scripts": "4.0.3",

--- a/client/src/util/cookie.ts
+++ b/client/src/util/cookie.ts
@@ -1,0 +1,7 @@
+import { Cookies } from 'react-cookie';
+
+const cookies = new Cookies();
+
+export const getCookie = (name: string) => {
+  return cookies.get(name);
+};

--- a/server/controller/login-controller.ts
+++ b/server/controller/login-controller.ts
@@ -8,7 +8,7 @@ export const login = async (req: Request, res: Response, next: Function) => {
   try {
     let user = await userService.findById(req.body.userId);
     if (user === undefined) user = await userService.signUp(req.body.userId);
-    res.cookie('user', createToken(user), { httpOnly: true });
+    res.cookie('user', createToken(user));
     res.status(201).json({ id: user.id, name: user.name });
   } catch (err: any) {
     next({ statusCode: 401, message: err.message });


### PR DESCRIPTION
- util/cookie.ts 파일의 getCookie 함수를 통해 쿠키를 접근할 수 있게 하였다.
- 로그인 정보에 관한 cookie를 접근하기위해 httpOnly 옵션을 없애주었다.
  - 보안적으로 문제가 있으므로 session 사용이 필요하지 않을까 생각된다.
- getCookie('user') 를 통해 loginCookie를 접근할 수 있다.