### PR TITLE
feat[#196] : 채팅페이지에서 participants 받아오기

### DIFF
--- a/client/src/page/chat/component/ChatBar.tsx
+++ b/client/src/page/chat/component/ChatBar.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import { ChatMenuDrawer } from './ChatMenuDrawer';
 import { Socket } from 'socket.io-client';
+import { ParticipantType } from '../../../type';
 const ChatBarLayout = css`
   display: flex;
   flex-direction: row;
@@ -26,6 +27,7 @@ const TitleStyle = css`
 type ChatBarType = {
   title: string;
   socket: Socket;
+  participants: ParticipantType[];
 };
 
 function ChatBar(props: ChatBarType) {
@@ -41,7 +43,7 @@ function ChatBar(props: ChatBarType) {
         }}
       />
       <div css={TitleStyle}>{props.title}</div>
-      <ChatMenuDrawer socket={props.socket} />
+      <ChatMenuDrawer socket={props.socket} participants={props.participants} />
     </div>
   );
 }

--- a/client/src/page/chat/component/ChatMenu.tsx
+++ b/client/src/page/chat/component/ChatMenu.tsx
@@ -6,6 +6,7 @@ import PointView from './PointView';
 import { Button } from '@mui/material';
 import { Socket } from 'socket.io-client';
 import { fetchGet, parsePath } from '../../../util';
+import { ParticipantType } from '../../../type';
 
 const ChatMenuStyle = css`
   width: 300px;
@@ -42,6 +43,7 @@ const QuitBtnStyle = css`
 type propsType = {
   onCloseBtnClicked: Function;
   socket: Socket;
+  participants: ParticipantType[];
 };
 
 export function ChatMenu(props: propsType) {

--- a/client/src/page/chat/component/ChatMenuDrawer.tsx
+++ b/client/src/page/chat/component/ChatMenuDrawer.tsx
@@ -4,6 +4,7 @@ import { SwipeableDrawer } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import { ChatMenu } from './ChatMenu';
 import { Socket } from 'socket.io-client';
+import { ParticipantType } from '../../../type';
 
 const BlurredBackground = css`
   position: fixed;
@@ -17,6 +18,7 @@ const BlurredBackground = css`
 
 type propsType = {
   socket: Socket;
+  participants: ParticipantType[];
 };
 
 export function ChatMenuDrawer(props: propsType) {
@@ -45,6 +47,7 @@ export function ChatMenuDrawer(props: propsType) {
         <ChatMenu
           onCloseBtnClicked={() => setIsMenuOn(false)}
           socket={props.socket}
+          participants={props.participants}
         />
       </SwipeableDrawer>
     </>

--- a/client/src/page/chat/index.tsx
+++ b/client/src/page/chat/index.tsx
@@ -5,7 +5,8 @@ import ChatInput from './component/ChatInput';
 import MyChatMessage from './component/MyChatMessage';
 import OtherChatMessage from './component/OtherChatMsg';
 import io from 'socket.io-client';
-import { getCurrentTime } from '../../util';
+import { fetchGet, getCurrentTime, parsePath } from '../../util';
+import { ParticipantType } from '../../type';
 
 const ChatContainer = css`
   margin-left: auto;
@@ -33,12 +34,20 @@ type MessageType = {
 };
 
 function Chat(props: any) {
-  const userId = props.location.state.userId;
-  const postId = props.location.state.postId;
-
+  const userId = '121212';
+  const postId = Number(parsePath(window.location.pathname).slice(-1)[0]);
   const socketRef = useRef<any>(io(String(process.env.REACT_APP_SERVER_URL)));
   const [chatDatas, setChatDatas] = useState<any>([]);
   const messageEndRef = useRef<HTMLDivElement>(null);
+
+  const [participants, setParticipants] = useState<ParticipantType[]>([]);
+
+  const updateParticipants = async (postId: number) => {
+    const url = `${process.env.REACT_APP_SERVER_URL}/api/chat/${postId}/participant`;
+    const result = await fetchGet(url);
+    setParticipants(result);
+  };
+
   const checkMe = (sender: string) => {
     return sender === userId;
   };
@@ -61,6 +70,7 @@ function Chat(props: any) {
         ];
       });
     });
+    updateParticipants(postId);
     return () => {
       socketRef.current.disconnect();
     };
@@ -79,6 +89,7 @@ function Chat(props: any) {
       <ChatBar
         title={'타이틀이 들어갈 공간입니당아아아'}
         socket={socketRef.current}
+        participants={participants}
       />
       <div css={ChatLayout}>
         {chatDatas.map((chat: MessageType) => {

--- a/client/src/page/detail/component/GroupBuyButton.tsx
+++ b/client/src/page/detail/component/GroupBuyButton.tsx
@@ -12,11 +12,6 @@ type GroupBuyButtonType = {
   finished: boolean;
 };
 
-const DUMMY_USER = {
-  id: 80206884,
-  name: 'J119_안병웅'
-};
-
 export default function GroupBuyButton({
   loginId,
   postId,
@@ -42,11 +37,7 @@ export default function GroupBuyButton({
       if (result === '해당 공구는 정원이 가득 찼습니다.') {
         alert(result);
         setButtonState(true);
-      } else
-        history.push(`/chat/${postId}`, {
-          userId: loginId,
-          postId
-        });
+      } else history.push(`/chat/${postId}`);
     }
   }, [history]);
   return (

--- a/client/src/type/index.ts
+++ b/client/src/type/index.ts
@@ -32,3 +32,12 @@ export interface QueryStringType {
   long?: number;
   search?: string;
 }
+
+export type ParticipantType = {
+  point: number;
+  user: {
+    id: number;
+    name: string;
+    img: string;
+  };
+};


### PR DESCRIPTION
- 채팅페이지의 index.ts 에서부터 Paritcipants를 받아와서 이를 props로 넘겨준다.
- 기존의 fetch를 여러번 하는 구조를 피하기위하여 이렇게 진행하였다.