### PR TITLE
feat[#220] : 사용자 방 입장시 실시간 업데이트 및 채팅방 나가기 후 뒤로가기 문제 해결

### DIFF
--- a/client/src/page/chat/component/ChatMenu.tsx
+++ b/client/src/page/chat/component/ChatMenu.tsx
@@ -86,7 +86,8 @@ export function ChatMenu(props: propsType) {
   const handleQuitClick = () => {
     props.socket.emit('quitRoom', getCookie('user'), postId);
     setIsConfirmOn(false);
-    history.push(`/post/${postId}`);
+    history.replace(`/post/${postId}`);
+    history.goBack();
   };
 
   return (

--- a/client/src/page/chat/index.tsx
+++ b/client/src/page/chat/index.tsx
@@ -84,6 +84,8 @@ function Chat() {
       });
     });
 
+    socketRef.current.emit('enterRoom');
+
     return () => {
       socketRef.current.disconnect();
     };

--- a/server/socket/chat.ts
+++ b/server/socket/chat.ts
@@ -7,11 +7,14 @@ import { TokenType } from '../type';
 import postService from '../service/post-service';
 
 export const joinRoom = (socket: any, io: Server) => {
-  socket.on('joinRoom', (postId: number, userId: number) => {
+  socket.on('joinRoom', async (postId: number, userId: number) => {
     console.log('user: ' + userId + ' has entered room: ' + postId);
     socket.join(String(postId));
     const joinMsg = `user ${userId} has join room ${postId}`;
     io.to(String(postId)).emit('afterJoin', joinMsg);
+
+    const participants = await participantService.getParticipants(postId);
+    io.to(String(postId)).emit('updateParticipants', participants);
   });
 };
 


### PR DESCRIPTION
- 다른 사용자가 채팅방에 입장하면 소켓으로 사용자 리스트를 갱신합니다.
- 채팅방 나가기 후 뒤로가기를 하면 다시 채팅방으로 돌아가는 문제를 수정하였습니다.