### PR TITLE
fix[#229] : 채팅참여 인원이 꽉 찼을 때 상세페이지 문제 해결 - close

### DIFF
--- a/client/src/page/detail/component/GroupBuyButton.tsx
+++ b/client/src/page/detail/component/GroupBuyButton.tsx
@@ -11,6 +11,7 @@ type GroupBuyButtonType = {
   participantCnt: number;
   capacity: number;
   finished: boolean;
+  isParticipate: boolean;
 };
 
 export default function GroupBuyButton({
@@ -18,13 +19,14 @@ export default function GroupBuyButton({
   postId,
   participantCnt,
   capacity,
-  finished
+  finished,
+  isParticipate
 }: GroupBuyButtonType) {
   const history = useHistory();
   const [isLoginModalOn, setIsLoginModalOn] = useState(false);
   const [buttonState, setButtonState] = useState(
     finished ||
-      (capacity !== null ? (participantCnt >= capacity ? true : false) : false)
+      (capacity !== null && participantCnt >= capacity && !isParticipate)
   );
   const clickHandler = useCallback(async () => {
     if (!login.isSigned) setIsLoginModalOn(true);
@@ -61,7 +63,8 @@ export default function GroupBuyButton({
       >
         {finished
           ? '모집 종료'
-          : `공동 구매 (${participantCnt} / ${capacity ?? ' - '})`}
+          : (isParticipate ? '참여중' : '공동 구매') +
+            ` (${participantCnt} / ${capacity ?? ' - '})`}
       </Button>
       {isLoginModalOn && <LoginModal setIsLoginModalOn={setIsLoginModalOn} />}
     </>

--- a/client/src/page/detail/index.tsx
+++ b/client/src/page/detail/index.tsx
@@ -42,6 +42,7 @@ type PostType = {
   capacity: number;
   participantCnt: number;
   urls: UrlType[];
+  isParticipate: boolean;
 };
 
 const detailContainer = css`
@@ -80,7 +81,8 @@ export default function Detail({ match }: RouteComponentProps<MatchParams>) {
     capacity: 0,
     deadline: '',
     participantCnt: 0,
-    urls: []
+    urls: [],
+    isParticipate: false
   });
   useEffect(() => {
     if (!loginUser.isSigned) {
@@ -217,6 +219,7 @@ export default function Detail({ match }: RouteComponentProps<MatchParams>) {
             participantCnt={post.participantCnt}
             capacity={post.capacity}
             finished={post.finished}
+            isParticipate={post.isParticipate}
           />
         </Box>
       </StyledBox>

--- a/server/controller/post-controller.ts
+++ b/server/controller/post-controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import postService from '../service/post-service';
 import participantService from '../service/participant-service';
 import { getPostsOption } from '../type';
+import { decodeToken } from '../util';
 
 export const getPosts = async (req: Request, res: Response, next: Function) => {
   try {
@@ -24,10 +25,17 @@ export const getPosts = async (req: Request, res: Response, next: Function) => {
 export const getPost = async (req: Request, res: Response, next: Function) => {
   try {
     const post = await postService.getPost(req.params.postId);
+    const userId = decodeToken(req.cookies.user);
+    if (userId === 'error') throw new Error('쿠키가 유효하지 않습니다.');
+    const isParticipate: boolean = await participantService.checkParticipation(
+      Number(req.params.postId),
+      userId
+    );
+
     const participantCnt = await participantService.getParticipantNum(
       Number(req.params.postId)
     );
-    res.json({ ...post, participantCnt });
+    res.json({ ...post, participantCnt, isParticipate });
   } catch (err: any) {
     next({ statusCode: 500, message: err.message });
   }

--- a/server/service/participant-service.ts
+++ b/server/service/participant-service.ts
@@ -63,11 +63,20 @@ const deleteParticipant = async (postId: number, userId: number) => {
   return result;
 };
 
+const checkParticipation = async (postId: number, userId: number) => {
+  const db = await getDB().get();
+  const result = await db.manager.findOne(Participant, {
+    where: { postId, userId }
+  });
+  return !(result === undefined);
+};
+
 export default {
   getParticipantNum,
   getParticipants,
   saveParticipant,
   getParticipant,
   updatePoint,
-  deleteParticipant
+  deleteParticipant,
+  checkParticipation
 };

--- a/server/util/index.ts
+++ b/server/util/index.ts
@@ -1,0 +1,12 @@
+import jwt from 'jsonwebtoken';
+import { TokenType } from '../type';
+
+export const decodeToken = (token: string) => {
+  try {
+    const secretKey: jwt.Secret = String(process.env.JWT_SECRET);
+    const { id: myId } = jwt.verify(token, secretKey) as TokenType;
+    return myId;
+  } catch {
+    return 'error';
+  }
+};


### PR DESCRIPTION
- 채팅 참여 인원이 꽉 차면 기존 참여자도 못들어가는 문제를 해결하였다.
- decodeToken 함수 util/index.ts에 넣어둠
 - chat.ts 와 post-controller에서 사용
- getPost에서 해당 post에 참여중인지 아닌지 확인하는 service 함수생성
  - participate service 의  checkParticipation 함수 구현
  - userId는 token으로 받아오도록 구현
- detail/index.ts 에서 isParticipate 를 GroupBuyButton에 넘겨주어 component 생성
  - 기존의 buttonState에 대한 삼항연산자가 너무 복잡하여 이를 간소화함
  - 참여중 기능 추가  GroupBuyButton


- 참여 안한 상태이며 공동 구매 진행중 인원 꽉 차 있을 때 
![image](https://user-images.githubusercontent.com/80206884/142482324-3ef1de09-1753-410c-8e7a-84f680062fc3.png)
- 참여 상태이며 공동 구매 진행중 인원 꽉 차 있을 때 
![image](https://user-images.githubusercontent.com/80206884/142482434-b64ae08e-1b46-4c84-8695-2a4ecdb20417.png)
- 공구에 참여중인 상태일 때 
![image](https://user-images.githubusercontent.com/80206884/142482536-015d0ade-c6cb-4c69-85a2-115c72c84264.png)


