### PR TITLE
fix[#237] - 채팅페이지 12시 관련 오류 해결

### DIFF
--- a/client/src/util/index.ts
+++ b/client/src/util/index.ts
@@ -88,6 +88,7 @@ export const getCurrentTime = () => {
   const currentMinutes = current.getMinutes();
   const strAmPm = currentHour < 12 ? '오전 ' : '오후 ';
   currentHour = currentHour < 12 ? currentHour : currentHour - 12;
+  if (currentHour === 0) currentHour = 12;
   return strAmPm + currentHour + '시 ' + currentMinutes + '분';
 };
 


### PR DESCRIPTION
- 12시가 될 경우 오전 12시의 경우 오전 0시, 오후 12시의 경우 오후 0시가 되었다.
- 따라서 현재시간이 0시가 되면 12시로 표현될 수 있도록 조건문 하나 넣어주었다.