### PR TITLE
fix[#240] : safari에서 채팅 좌,우 반영안되는 오류 해결 

### DIFF
--- a/client/src/page/chat/component/MyChatMessage.tsx
+++ b/client/src/page/chat/component/MyChatMessage.tsx
@@ -20,7 +20,7 @@ const MessageStyle = css`
 
 const DirectionSelector = css`
   display: flex;
-  justify-content: right;
+  justify-content: flex-end;
   align-items: flex-end;
 `;
 

--- a/client/src/page/chat/component/OtherChatMsg.tsx
+++ b/client/src/page/chat/component/OtherChatMsg.tsx
@@ -19,7 +19,7 @@ const MessageStyle = css`
 
 const DirectionSelector = css`
   display: flex;
-  justify-content: left;
+  justify-content: flex-start;
   align-items: flex-end;
 `;
 


### PR DESCRIPTION
- 사파리에서는 justifyContent가 right, left 속성이 작동하지 않는다.
- 이를 flex-start, flex-end로 바꿔주었다.