### PR TITLE
feat[#244] : 채팅방 강제 퇴장을 당한 클라이언트에서 페이지 이동 처리

### DIFF
--- a/client/src/page/chat/component/PointView.tsx
+++ b/client/src/page/chat/component/PointView.tsx
@@ -89,6 +89,10 @@ function PointView(props: PointState) {
     const me = props.participants.find(participant => {
       return participant.user.id === loginUser.id;
     }) as ParticipantType;
+    if (!me) {
+      setDisabled(true);
+      return;
+    }
     if (me.point !== null && me.point !== undefined) {
       setMyPoint(String(me.point));
       setPurchase(true);

--- a/server/socket/chat.ts
+++ b/server/socket/chat.ts
@@ -115,6 +115,9 @@ export const kickUser = (socket: any, io: Server) => {
       // 변경된 참여자 리스트를 클라이언트에 반환
       const participants = await participantService.getParticipants(postId);
       io.to(String(postId)).emit('updateParticipants', participants);
+
+      // 강제퇴장 당한 클라이언트에게 이벤트 전달
+      io.to(String(postId)).emit('getOut', targetUserId);
     }
   );
 };


### PR DESCRIPTION
- 공동 구매 참여자가 채팅 페이지에 들어와 있는 상태에서 강제 퇴장을 당할 경우, 안내 메시지와 함께 뒤로 가기 처리

![1](https://user-images.githubusercontent.com/76616101/142830339-13e6b0aa-a73c-426a-80c4-d1e205d1e2d1.gif)

