### PR TITLE
호스트 채팅 메뉴에서 포인트를 가져오면 공구 종료 상태로 변경

### DIFF
--- a/client/src/page/chat/component/ChatMenu.tsx
+++ b/client/src/page/chat/component/ChatMenu.tsx
@@ -85,6 +85,10 @@ export function ChatMenu(props: propsType) {
     props.socket.on('finishPost', () => {
       setPointViewState(FINISHED);
     });
+
+    return () => {
+      props.socket.off('finishPost');
+    };
   }, []);
 
   const handleQuitClick = () => {

--- a/client/src/page/chat/component/ChatMenu.tsx
+++ b/client/src/page/chat/component/ChatMenu.tsx
@@ -80,6 +80,10 @@ export function ChatMenu(props: propsType) {
   useEffect(() => {
     updateHostId();
     updateFinished();
+
+    props.socket.on('finishPost', () => {
+      setPointViewState(FINISHED);
+    });
   }, []);
 
   const handleQuitClick = () => {

--- a/client/src/page/chat/component/ChatMenu.tsx
+++ b/client/src/page/chat/component/ChatMenu.tsx
@@ -13,6 +13,7 @@ import Confirm from '../../../common/confirm';
 import { useHistory } from 'react-router';
 import { useRecoilValue } from 'recoil';
 import { loginUserState } from '../../../store/login';
+import FinishedPointView from './FinishedPointView';
 
 const ChatMenuStyle = css`
   width: 300px;
@@ -103,7 +104,7 @@ export function ChatMenu(props: propsType) {
       />
       {
         [
-          <></>,
+          <FinishedPointView />,
           <HostPointView
             socket={props.socket}
             hostId={hostId}

--- a/client/src/page/chat/component/FinishedPointView.tsx
+++ b/client/src/page/chat/component/FinishedPointView.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { css } from '@emotion/react';
+
+const FinishedPointViewStyle = css`
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, 0);
+  width: 95%;
+  bottom: 120px;
+  padding: 0 15px;
+
+  & > h1 {
+    font-family: 'Noto Sans KR Medium', sans-serif;
+    font-size: 24px;
+  }
+
+  & > ul {
+    list-style: none;
+    padding-left: 0;
+  }
+`;
+
+function FinishedPointView() {
+  return (
+    <div css={FinishedPointViewStyle}>
+      <h1>거래가 종료되었습니다</h1>
+    </div>
+  );
+}
+
+export default FinishedPointView;

--- a/client/src/page/chat/component/FinishedPointView.tsx
+++ b/client/src/page/chat/component/FinishedPointView.tsx
@@ -8,22 +8,19 @@ const FinishedPointViewStyle = css`
   width: 95%;
   bottom: 120px;
   padding: 0 15px;
+  display: flex;
+  justify-content: center;
 
-  & > h1 {
+  & > h2 {
     font-family: 'Noto Sans KR Medium', sans-serif;
     font-size: 24px;
-  }
-
-  & > ul {
-    list-style: none;
-    padding-left: 0;
   }
 `;
 
 function FinishedPointView() {
   return (
     <div css={FinishedPointViewStyle}>
-      <h1>거래가 종료되었습니다</h1>
+      <h2>거래가 종료되었습니다</h2>
     </div>
   );
 }

--- a/client/src/page/chat/component/HostPointView.tsx
+++ b/client/src/page/chat/component/HostPointView.tsx
@@ -50,6 +50,7 @@ function HostPointView(props: PointState) {
   });
 
   const handleTakePointBtnClick = () => {
+    setIsConfirmOn(false);
     socket.emit(`takePoint`, postId);
     setDisabled(false);
     setFinished(true);

--- a/client/src/page/chat/component/HostPointView.tsx
+++ b/client/src/page/chat/component/HostPointView.tsx
@@ -104,7 +104,7 @@ function HostPointView(props: PointState) {
   });
 
   const handlePointBtnClick = () => {
-    socket.emit(`post finish`, postId);
+    socket.emit(`takePoint`, postId);
     setDisabled(false);
     setFinished(true);
   };

--- a/client/src/page/chat/component/HostPointView.tsx
+++ b/client/src/page/chat/component/HostPointView.tsx
@@ -1,71 +1,9 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import { Socket } from 'socket.io-client';
 import Button from '@mui/material/Button';
-import { fetchGet, parsePath } from '../../../util';
+import { parsePath } from '../../../util';
 import { ParticipantType } from '../../../type';
-
-const HostPointViewStyle = css`
-  position: absolute;
-  left: 50%;
-  transform: translate(-50%, 0);
-  width: 95%;
-  bottom: 120px;
-  padding: 0 15px;
-
-  & > h1 {
-    font-family: 'Noto Sans KR Medium', sans-serif;
-    font-size: 16px;
-  }
-
-  & > ul {
-    list-style: none;
-    padding-left: 0;
-  }
-`;
-
-const PointContainer = css`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-`;
-
-const PointInputStyle = css`
-  border: 0px solid;
-  border-bottom: 2px solid #f97d63;
-  box-sizing: border-box;
-  box-shadow: none;
-  width: 70%;
-  height: 40px;
-  background: transparent;
-  outline: none;
-  color: #000000;
-  font-size: 16px;
-  overflow: hidden;
-  padding: 10px;
-  &:-webkit-outer-spin-button,
-  &:-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
-`;
-
-const PointBtnStyle = (disabled: boolean) => css`
-  width: 100%;
-  background-color: ${disabled ? `#b6e3e9` : `#fdafab`};
-  color: white;
-  &:hover {
-    background-color: ${disabled ? '#b6e3e9' : '#fdafab'};
-  }
-`;
-
-type PointState = {
-  socket: Socket;
-  hostId: number;
-  participants: ParticipantType[];
-};
 
 function HostPointView(props: PointState) {
   const socket = props.socket;
@@ -129,3 +67,44 @@ function HostPointView(props: PointState) {
 
 export default React.memo(HostPointView);
 //
+const HostPointViewStyle = css`
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, 0);
+  width: 95%;
+  bottom: 120px;
+  padding: 0 15px;
+
+  & > h1 {
+    font-family: 'Noto Sans KR Medium', sans-serif;
+    font-size: 16px;
+  }
+
+  & > ul {
+    list-style: none;
+    padding-left: 0;
+  }
+`;
+
+const PointContainer = css`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`;
+
+const PointBtnStyle = (disabled: boolean) => css`
+  width: 100%;
+  background-color: ${disabled ? `#b6e3e9` : `#fdafab`};
+  color: white;
+  &:hover {
+    background-color: ${disabled ? '#b6e3e9' : '#fdafab'};
+  }
+`;
+
+type PointState = {
+  socket: Socket;
+  hostId: number;
+  participants: ParticipantType[];
+};

--- a/client/src/page/chat/component/HostPointView.tsx
+++ b/client/src/page/chat/component/HostPointView.tsx
@@ -4,12 +4,14 @@ import { Socket } from 'socket.io-client';
 import Button from '@mui/material/Button';
 import { parsePath } from '../../../util';
 import { ParticipantType } from '../../../type';
+import Confirm from '../../../common/confirm';
 
 function HostPointView(props: PointState) {
   const socket = props.socket;
   const [allPoint, setAllPoint] = useState<number>();
   const [disabled, setDisabled] = useState<boolean>(false);
   const [finished, setFinished] = useState(false);
+  const [isConfirmOn, setIsConfirmOn] = useState(false);
   const postId = Number(parsePath(window.location.pathname).slice(-1)[0]);
 
   const isAllReady = (participantss: ParticipantType[]) => {
@@ -41,7 +43,7 @@ function HostPointView(props: PointState) {
     setFinished(false);
   });
 
-  const handlePointBtnClick = () => {
+  const handleTakePointBtnClick = () => {
     socket.emit(`takePoint`, postId);
     setDisabled(false);
     setFinished(true);
@@ -53,7 +55,7 @@ function HostPointView(props: PointState) {
       <div css={PointContainer}>
         <Button
           css={PointBtnStyle(disabled)}
-          onClick={handlePointBtnClick}
+          onClick={() => setIsConfirmOn(true)}
           disabled={disabled}
         >
           {!disabled
@@ -61,6 +63,14 @@ function HostPointView(props: PointState) {
             : `${finished ? '공구 완료!' : '아직 불가능!'}`}
         </Button>
       </div>
+      <Confirm
+        on={isConfirmOn}
+        title="포인트 가져오기"
+        onCancel={() => setIsConfirmOn(false)}
+        onConfirm={handleTakePointBtnClick}
+      >
+        정말 {allPoint} 포인트를 가져오시겠습니까?
+      </Confirm>
     </div>
   );
 }

--- a/client/src/page/chat/component/PointView.tsx
+++ b/client/src/page/chat/component/PointView.tsx
@@ -6,6 +6,7 @@ import { useRecoilValue } from 'recoil';
 import { loginUserState } from '../../../store/login';
 import { fetchGet, parsePath } from '../../../util';
 import { ParticipantType } from '../../../type';
+import Confirm from '../../../common/confirm';
 
 type PointState = {
   socket: Socket;
@@ -19,6 +20,7 @@ function PointView(props: PointState) {
   const [disabled, setDisabled] = useState<boolean>(true);
   const [purchase, setPurchase] = useState<boolean>(false);
   const [leftPoint, setLeftPoint] = useState<number>();
+  const [isConfirmOn, setIsConfirmOn] = useState(false);
   const loginUser = useRecoilValue(loginUserState);
   const postId = Number(parsePath(window.location.pathname).slice(-1)[0]);
 
@@ -55,7 +57,7 @@ function PointView(props: PointState) {
     else setDisabled(true);
   };
 
-  const handlePointBtnClick = () => {
+  const handleSubmitPointBtnClick = () => {
     setDisabled(true);
     if (!purchase)
       socket.emit('point confirm', postId, loginUser.id, Number(myPoint));
@@ -75,13 +77,21 @@ function PointView(props: PointState) {
         />
         <Button
           css={PointBtnStyle(purchase, disabled)}
-          onClick={handlePointBtnClick}
+          onClick={() => setIsConfirmOn(true)}
           disabled={disabled}
         >
           {purchase ? '취소' : '확정'}
         </Button>
       </div>
       <span css={leftPointStyle}>잔여 포인트 : {leftPoint}</span>
+      <Confirm
+        on={isConfirmOn}
+        title="포인트 제출하기"
+        onCancel={() => setIsConfirmOn(false)}
+        onConfirm={handleSubmitPointBtnClick}
+      >
+        정말 {myPoint} 포인트를 내시겠습니까?
+      </Confirm>
     </div>
   );
 }

--- a/client/src/page/chat/component/PointView.tsx
+++ b/client/src/page/chat/component/PointView.tsx
@@ -62,6 +62,7 @@ function PointView(props: PointState) {
   };
 
   const handleSubmitPointBtnClick = () => {
+    setIsConfirmOn(false);
     setDisabled(true);
     if (!purchase)
       socket.emit('point confirm', postId, loginUser.id, Number(myPoint));
@@ -90,11 +91,13 @@ function PointView(props: PointState) {
       <span css={leftPointStyle}>잔여 포인트 : {leftPoint}</span>
       <Confirm
         on={isConfirmOn}
-        title="포인트 제출하기"
+        title={!purchase ? '포인트 제출하기' : '제출 취소하기'}
         onCancel={() => setIsConfirmOn(false)}
         onConfirm={handleSubmitPointBtnClick}
       >
-        정말 {myPoint} 포인트를 내시겠습니까?
+        {!purchase
+          ? `정말 ${myPoint}포인트를 제출하시겠습니까?`
+          : `정말 포인트 제출을 취소하시겠습니까?`}
       </Confirm>
     </div>
   );

--- a/client/src/page/chat/component/PointView.tsx
+++ b/client/src/page/chat/component/PointView.tsx
@@ -7,69 +7,6 @@ import { loginUserState } from '../../../store/login';
 import { fetchGet, parsePath } from '../../../util';
 import { ParticipantType } from '../../../type';
 
-const PointViewStyle = css`
-  position: absolute;
-  left: 50%;
-  transform: translate(-50%, 0);
-  width: 95%;
-  bottom: 120px;
-  padding: 0 15px;
-
-  & > h1 {
-    font-family: 'Noto Sans KR Medium', sans-serif;
-    font-size: 16px;
-  }
-
-  & > ul {
-    list-style: none;
-    padding-left: 0;
-  }
-`;
-
-const PointContainer = css`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-`;
-
-const PointInputStyle = css`
-  border: 0px solid;
-  border-bottom: 2px solid #f97d63;
-  box-sizing: border-box;
-  box-shadow: none;
-  width: 70%;
-  height: 40px;
-  background: transparent;
-  outline: none;
-  color: #000000;
-  font-size: 16px;
-  overflow: hidden;
-  padding: 10px;
-  &:-webkit-outer-spin-button,
-  &:-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
-`;
-
-const PointBtnStyle = (purchase: boolean, disabled: boolean) => css`
-  width: 15%;
-  background-color: ${purchase
-    ? `#b6e3e9${disabled ? '99' : ''}`
-    : `#fdafab${disabled ? '99' : ''}`};
-  color: white;
-  &:hover {
-    background-color: ${purchase ? '#b6e3e9' : '#fdafab'};
-  }
-`;
-
-const leftPointStyle = css`
-  font-size: 9px;
-  color: #cccccc;
-`;
-
 type PointState = {
   socket: Socket;
   hostId: number;
@@ -150,3 +87,66 @@ function PointView(props: PointState) {
 }
 
 export default React.memo(PointView);
+
+const PointViewStyle = css`
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, 0);
+  width: 95%;
+  bottom: 120px;
+  padding: 0 15px;
+
+  & > h1 {
+    font-family: 'Noto Sans KR Medium', sans-serif;
+    font-size: 16px;
+  }
+
+  & > ul {
+    list-style: none;
+    padding-left: 0;
+  }
+`;
+
+const PointContainer = css`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`;
+
+const PointInputStyle = css`
+  border: 0px solid;
+  border-bottom: 2px solid #f97d63;
+  box-sizing: border-box;
+  box-shadow: none;
+  width: 70%;
+  height: 40px;
+  background: transparent;
+  outline: none;
+  color: #000000;
+  font-size: 16px;
+  overflow: hidden;
+  padding: 10px;
+  &:-webkit-outer-spin-button,
+  &:-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+`;
+
+const PointBtnStyle = (purchase: boolean, disabled: boolean) => css`
+  width: 15%;
+  background-color: ${purchase
+    ? `#b6e3e9${disabled ? '99' : ''}`
+    : `#fdafab${disabled ? '99' : ''}`};
+  color: white;
+  &:hover {
+    background-color: ${purchase ? '#b6e3e9' : '#fdafab'};
+  }
+`;
+
+const leftPointStyle = css`
+  font-size: 9px;
+  color: #cccccc;
+`;

--- a/server/ormconfig.js
+++ b/server/ormconfig.js
@@ -1,20 +1,20 @@
 require('dotenv').config();
 
 module.exports = {
-	type: 'mysql',
-	host: process.env.DB_HOST,
-	port: process.env.DB_PORT,
-	username: process.env.DB_USERNAME,
-	password: process.env.DB_PASSWORD,
-	database: process.env.DB_DBNAME,
-	synchronize: true,
-	logging: false,
-	entities: ['model/entity/**/*.ts'],
-	migrations: ['model/migration/**/*.ts'],
-	subscribers: ['model/subscriber/**/*.ts'],
-	cli: {
-		entitiesDir: 'model/entity',
-		migrationsDir: 'model/migrations',
-		subscribersDir: 'model/subscriber'
-	}
+  type: 'mysql',
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT,
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_DBNAME,
+  synchronize: true,
+  logging: false,
+  entities: ['model/entity/**/*.ts'],
+  migrations: ['model/migration/**/*.ts'],
+  subscribers: ['model/subscriber/**/*.ts'],
+  cli: {
+    entitiesDir: 'model/entity',
+    migrationsDir: 'model/migrations',
+    subscribersDir: 'model/subscriber'
+  }
 };

--- a/server/service/participant-service.ts
+++ b/server/service/participant-service.ts
@@ -75,7 +75,7 @@ const finishPost = async (postId: number, hostId: number) => {
   const db = await getDB().get();
   const sql = `
   UPDATE user SET point = point + (SELECT SUM(p.point) as sum
-                          FROM participant
+                          FROM participant p
                           WHERE postId = ${postId}
                           GROUP BY postId)
   WHERE id = ${hostId}

--- a/server/service/participant-service.ts
+++ b/server/service/participant-service.ts
@@ -71,6 +71,19 @@ const checkParticipation = async (postId: number, userId: number) => {
   return !(result === undefined);
 };
 
+const finishPost = async (postId: number, hostId: number) => {
+  const db = await getDB().get();
+  const sql = `
+  UPDATE user SET point = point + (SELECT SUM(p.point) as sum
+                          FROM participant
+                          WHERE postId = ${postId}
+                          GROUP BY postId)
+  WHERE id = ${hostId}
+  `;
+  const result = await db.manager.query(sql);
+  return result;
+};
+
 export default {
   getParticipantNum,
   getParticipants,
@@ -78,5 +91,6 @@ export default {
   getParticipant,
   updatePoint,
   deleteParticipant,
-  checkParticipation
+  checkParticipation,
+  finishPost
 };

--- a/server/service/post-service.ts
+++ b/server/service/post-service.ts
@@ -1,9 +1,7 @@
 import { Request } from 'express';
-import { title } from 'process';
 import { getDB } from '../db/db';
 import { Post } from '../model/entity/Post';
-import { Url } from '../model/entity/Url';
-import { PostColumn, getPostsOption } from '../type';
+import { getPostsOption } from '../type';
 
 const savePost = async (body: Request['body']): Promise<number> => {
   const db = await getDB().get();

--- a/server/socket/index.ts
+++ b/server/socket/index.ts
@@ -7,7 +7,8 @@ import {
   joinRoom,
   sendMsg,
   kickUser,
-  quitRoom
+  quitRoom,
+  finishRoom
 } from './chat';
 
 export const socketInit = (server: any, app: Application) => {
@@ -24,6 +25,7 @@ export const socketInit = (server: any, app: Application) => {
     cancelPurchase(socket, io);
     kickUser(socket, io);
     quitRoom(socket, io);
+    finishRoom(socket, io);
 
     socket.on('disconnect', () => {
       console.log('socket disconnected!');


### PR DESCRIPTION
- 포인트 제출 / 제출취소 / 가져오기 할때 confirm창 띄워주어 확인
- 호스트가 포인트 가져오기시 거래 종료로 변경
- 종료된 채팅에서는 거래가 종료되었다는 안내문구 표시
- queryRunner를 이용해 트랜잭션 실패시 롤백 되는 로직 적용