### PR TITLE
feat[#287] : 상세 페이지 UI 수정

### DIFF
--- a/client/src/page/detail/index.tsx
+++ b/client/src/page/detail/index.tsx
@@ -243,9 +243,6 @@ export default function Detail({ match }: RouteComponentProps<MatchParams>) {
         }}
       >
         <Box sx={{ display: 'flex', p: 1 }}>
-          <StyledIconButton sx={{ bgcolor: 'white', p: 1, m: 1 }}>
-            <FavoriteBorderIcon sx={{ fontSize: 30 }} />
-          </StyledIconButton>
           <GroupBuyButton
             login={loginUser}
             postId={Number(match.params.postId)}

--- a/client/src/page/detail/index.tsx
+++ b/client/src/page/detail/index.tsx
@@ -6,7 +6,8 @@ import {
   IconButton,
   CircularProgress,
   Chip,
-  Box
+  Box,
+  Avatar
 } from '@mui/material';
 import styled from '@emotion/styled';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
@@ -23,6 +24,13 @@ import { loginUserState } from '../../store/login';
 type UrlType = {
   postId: number;
   url: string;
+};
+
+type UserType = {
+  id: number;
+  name: string;
+  img: string;
+  point: number;
 };
 
 type MatchParams = {
@@ -42,6 +50,7 @@ type PostType = {
   capacity: number;
   participantCnt: number;
   urls: UrlType[];
+  user: UserType;
   isParticipate: boolean;
 };
 
@@ -83,6 +92,12 @@ export default function Detail({ match }: RouteComponentProps<MatchParams>) {
     deadline: '',
     participantCnt: 0,
     urls: [],
+    user: {
+      id: 0,
+      name: '',
+      img: '',
+      point: 0
+    },
     isParticipate: false
   });
   useEffect(() => {
@@ -175,7 +190,18 @@ export default function Detail({ match }: RouteComponentProps<MatchParams>) {
               mt: 2
             }}
           >
-            <Typography variant="body1">작성자| {post.userId}</Typography>
+            <Typography
+              variant="body1"
+              sx={{
+                display: 'flex'
+              }}
+            >
+              <Avatar
+                src={post.user.img}
+                sx={{ width: 32, height: 32, marginRight: 1 }}
+              />
+              {post.user.name}
+            </Typography>
             <DeadLine
               ref={deadLineRef}
               isNeedServerTime={isNeedServerTime}

--- a/server/service/post-service.ts
+++ b/server/service/post-service.ts
@@ -76,7 +76,7 @@ const getPost = async (postId: string) => {
   try {
     const post = await db.manager.findOne(Post, {
       where: { id: postId },
-      relations: ['category', 'urls']
+      relations: ['category', 'urls', 'user']
     });
     return post;
   } catch (e) {


### PR DESCRIPTION
- 작성자(호스트)의 아이디 대신에 프로필 사진과 이름을 출력하도록 구현했습니다.
- 하단의 찜 버튼을 제거하였습니다.

<img src="https://user-images.githubusercontent.com/76616101/143056461-319bac5a-79d6-4987-8ce4-ef28c956f1d7.png" width="400" />
