### PR TITLE
fix[#298] : 마이 페이지 스타일 관련 버그 수정

### DIFF
--- a/client/src/common/post-list/component/Item.tsx
+++ b/client/src/common/post-list/component/Item.tsx
@@ -21,6 +21,7 @@ const ItemStyle = css`
   height: 120px;
   margin-bottom: 15px;
   border-radius: 10px;
+  background-color: #ffffff;
   box-shadow: 3px 3px 8px 1px #bbbbbb;
 `;
 

--- a/client/src/page/mypage/component/ChargePointModal.tsx
+++ b/client/src/page/mypage/component/ChargePointModal.tsx
@@ -13,6 +13,7 @@ const PointModalBgStyle = css`
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(4px);
+  z-index: 1;
 `;
 
 const PointModalStyle = css`

--- a/client/src/page/mypage/component/ReturnPointModal.tsx
+++ b/client/src/page/mypage/component/ReturnPointModal.tsx
@@ -13,6 +13,7 @@ const PointModalBgStyle = css`
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(4px);
+  z-index: 1;
 `;
 
 const PointModalStyle = css`


### PR DESCRIPTION
- 마이 페이지의 충전/반환 버튼을 누르면 나오는 포인트 모달이 게시글 리스트 밑에 깔려 가려지는 문제를 수정하였습니다.
  - 충전/반환 포인트 모달에 `z-index: 1` 설정
- 마이 페이지의 '참여한 공동구매' 리스트에서 각 아이템의 배경색이 투명하여 페이지 배경이 비쳐 보이는 문제를 수정하였습니다.
  - 게시글 리스트 각 아이템에 배경색 `#ffffff`을 추가하였습니다.