### PR TITLE
refactor[#321] : 서치 모달 리팩토링

### DIFF
--- a/client/src/common/search-modal/component/ButtonSet.tsx
+++ b/client/src/common/search-modal/component/ButtonSet.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { Button } from '@mui/material';
+
+interface ButtonSetProps {
+  onCancel?: () => void;
+  onSubmit?: () => void;
+}
+
+export default function ButtonSet(props: ButtonSetProps) {
+  return (
+    <div css={ButtonSetStyle}>
+      <Button variant="contained" css={ButtonStyle('#D9D5D5')} onClick={props.onCancel}>
+        취소
+      </Button>
+      <Button variant="contained" css={ButtonStyle('#ebabab')} onClick={props.onSubmit}>
+        완료
+      </Button>
+    </div>
+  );
+}
+
+const ButtonSetStyle = css`
+  text-align: right;
+`;
+
+const ButtonStyle = (bgColor: string) => css`
+  background-color: ${bgColor};
+  margin-left: 15px;
+`;

--- a/client/src/common/search-modal/component/FilterOption.tsx
+++ b/client/src/common/search-modal/component/FilterOption.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { css } from '@emotion/react';
+
+interface FilterOptionProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+export default function FilterOption({ title, children }: FilterOptionProps) {
+  return (
+    <div css={FilterOptionStyle}>
+      <h3>{title}</h3>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+const FilterOptionStyle = css`
+  & > h3 {
+    margin-bottom: 5px;
+  }
+  & > div {
+    display: flex;
+    flex-wrap: wrap;
+  }
+`;

--- a/client/src/common/search-modal/component/Select.tsx
+++ b/client/src/common/search-modal/component/Select.tsx
@@ -22,7 +22,7 @@ export default function Select(props: SelectProps) {
   return (
     <div>
       {props.options.map((e, i) => (
-        <SelectChip selected={props.selected[i]} onClick={() => handleSelect(i)}>
+        <SelectChip key={i} selected={props.selected[i]} onClick={() => handleSelect(i)}>
           {e}
         </SelectChip>
       ))}

--- a/client/src/common/search-modal/component/Select.tsx
+++ b/client/src/common/search-modal/component/Select.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect } from 'react';
+import SelectChip from './SelectChip';
+
+interface SelectProps {
+  options: string[];
+  selected: boolean[];
+  setSelected: (selected: boolean[]) => void;
+}
+
+export default function Select(props: SelectProps) {
+  useEffect(() => {
+    const defaultValue = new Array(props.options.length).fill(false);
+    props.setSelected(defaultValue);
+  }, []);
+
+  const handleSelect = (idx: number) => {
+    const newVal = [...props.selected];
+    newVal[idx] = !newVal[idx];
+    props.setSelected(newVal);
+  };
+
+  return (
+    <div>
+      {props.options.map((e, i) => (
+        <SelectChip selected={props.selected[i]} onClick={() => handleSelect(i)}>
+          {e}
+        </SelectChip>
+      ))}
+    </div>
+  );
+}

--- a/client/src/common/search-modal/component/SelectChip.tsx
+++ b/client/src/common/search-modal/component/SelectChip.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { Chip } from '@mui/material';
+
+interface SelectChipProps {
+  selected: boolean;
+  children: React.ReactNode;
+  onClick?: () => void;
+}
+
+export default function FilterOption({ selected, children, onClick }: SelectChipProps) {
+  return <Chip label={children} css={ChipStyle(selected)} onClick={onClick} />;
+}
+
+const ChipStyle = (checked: boolean) => {
+  return css`
+    width: 80px;
+    margin: 3px 3px;
+    ${checked ? 'background-color: #ebabab; color: #ffffff;' : ''}
+    &:hover {
+      background-color: #ebe4e4;
+      ${checked ? 'background-color: #ebabab;' : ''}
+    }
+  `;
+};

--- a/client/src/common/search-modal/index.tsx
+++ b/client/src/common/search-modal/index.tsx
@@ -9,6 +9,7 @@ import { Chip } from '@mui/material';
 import { boolToNum, createQueryString, decomposeQueryString, finishedToBool, getAddressByGeocode } from '../../util';
 import { LocationType } from '../../type';
 import service from '../../util/service';
+import FilterOption from './component/FilterOption';
 
 const FINISHED_LIST = ['공구중', '공구완료'];
 
@@ -42,6 +43,7 @@ export default function SearchModal({ setIsSearchModalOn, history }: SearchModal
       return arr;
     });
   };
+
   const handleFinishedClick = (idx: number) => {
     setCheckedFinished(checkedFinished => {
       const arr = [...checkedFinished];
@@ -63,12 +65,11 @@ export default function SearchModal({ setIsSearchModalOn, history }: SearchModal
     const queryStr = createQueryString(query);
     history.push('/?' + queryStr);
   };
-  useEffect(() => {
-    setLocation(currentLocation);
-  }, [currentLocation]);
+
   useEffect(() => {
     if (JSON.stringify(location) !== JSON.stringify({ lat: 0, lng: 0 })) searchCoordinateToAddress(location);
   }, [location]);
+
   useEffect(() => {
     service.getCategories().then(result => {
       setCategories(result.map((x: any) => x.name));
@@ -96,41 +97,36 @@ export default function SearchModal({ setIsSearchModalOn, history }: SearchModal
     <div>
       <div css={searchModal}>
         <SearchInput value={search} setSearch={setSearch} />
-        <div css={CategoryStyle}>
-          <h3>카테고리</h3>
+        <FilterOption title="카테고리">
+          {categories.map((category, i) => (
+            <Chip
+              label={category}
+              css={ChipStyle(checkedCategories[i])}
+              onClick={() => {
+                handleCategoryClick(i);
+              }}
+              data-idx={i}
+            />
+          ))}
+        </FilterOption>
+        <FilterOption title="공구 상태">
+          {FINISHED_LIST.map((finished, i) => (
+            <Chip
+              label={finished}
+              css={ChipStyle(checkedFinished[i])}
+              onClick={() => {
+                handleFinishedClick(i);
+              }}
+              data-idx={i}
+            />
+          ))}
+        </FilterOption>
+        <FilterOption title="위치">
           <div>
-            {categories.map((category, i) => (
-              <Chip
-                label={category}
-                css={ChipStyle(checkedCategories[i])}
-                onClick={() => {
-                  handleCategoryClick(i);
-                }}
-                data-idx={i}
-              />
-            ))}
+            <p>{address}</p>
+            <MapDrawer setLocation={setLocation} location={location} />
           </div>
-        </div>
-        <div css={StateStyle}>
-          <h3>공구 상태</h3>
-          <div>
-            {FINISHED_LIST.map((finished, i) => (
-              <Chip
-                label={finished}
-                css={ChipStyle(checkedFinished[i])}
-                onClick={() => {
-                  handleFinishedClick(i);
-                }}
-                data-idx={i}
-              />
-            ))}
-          </div>
-        </div>
-        <div css={LocationStyle}>
-          <h3>위치</h3>
-          <p>{address}</p>
-          <MapDrawer setLocation={setLocation} location={location} />
-        </div>
+        </FilterOption>
         <div css={buttonContainerStyle}>
           <Button
             variant="contained"
@@ -171,16 +167,6 @@ const searchModal = css`
   padding: 10px;
 `;
 
-const CategoryStyle = css`
-  & > h3 {
-    margin-bottom: 5px;
-  }
-  & > div {
-    display: flex;
-    flex-wrap: wrap;
-  }
-`;
-
 const ChipStyle = (checked: boolean) => {
   return css`
     width: 80px;
@@ -192,26 +178,6 @@ const ChipStyle = (checked: boolean) => {
     }
   `;
 };
-
-const StateStyle = css`
-  & > h3 {
-    margin-bottom: 5px;
-  }
-  & > div {
-    display: flex;
-    flex-wrap: wrap;
-  }
-`;
-
-const LocationStyle = css`
-  & > h3 {
-    margin-bottom: 5px;
-  }
-  & > div {
-    display: flex;
-    flex-wrap: wrap;
-  }
-`;
 
 const buttonContainerStyle = css`
   text-align: right;

--- a/client/src/common/search-modal/index.tsx
+++ b/client/src/common/search-modal/index.tsx
@@ -6,79 +6,20 @@ import { useRecoilValue } from 'recoil';
 import MapDrawer from './component/MapDrawer';
 import SearchInput from './component/SearchInput';
 import { Chip } from '@mui/material';
-import {
-  boolToNum,
-  createQueryString,
-  decomposeQueryString,
-  fetchGet,
-  finishedToBool,
-  getAddressByGeocode
-} from '../../util';
+import { boolToNum, createQueryString, decomposeQueryString, finishedToBool, getAddressByGeocode } from '../../util';
 import { LocationType } from '../../type';
-
-const searchModal = css`
-  max-width: 700px;
-  margin-left: auto;
-  margin-right: auto;
-  width: 100vw;
-  height: 100vh;
-  background-color: #fff7f7;
-  z-index: 1;
-  padding: 10px;
-`;
-
-const CategoryStyle = css`
-  & > h3 {
-    margin-bottom: 5px;
-  }
-  & > div {
-    display: flex;
-    flex-wrap: wrap;
-  }
-`;
-
-const ChipStyle = (checked: boolean) => {
-  return css`
-    width: 80px;
-    margin: 3px 3px;
-    ${checked ? 'background-color: #ebabab; color: #ffffff;' : ''}
-    &:hover {
-      background-color: #ebe4e4;
-      ${checked ? 'background-color: #ebabab;' : ''}
-    }
-  `;
-};
-
-const StateStyle = css`
-  & > h3 {
-    margin-bottom: 5px;
-  }
-  & > div {
-    display: flex;
-    flex-wrap: wrap;
-  }
-`;
-
-const LocationStyle = css`
-  & > h3 {
-    margin-bottom: 5px;
-  }
-  & > div {
-    display: flex;
-    flex-wrap: wrap;
-  }
-`;
-
-const buttonContainerStyle = css`
-  text-align: right;
-`;
+import service from '../../util/service';
 
 const FINISHED_LIST = ['공구중', '공구완료'];
 
-function SearchModal({ setIsSearchModalOn, history }: { setIsSearchModalOn: any; history: any }) {
+interface SearchModalPropsType {
+  setIsSearchModalOn: any;
+  history: any;
+}
+
+export default function SearchModal({ setIsSearchModalOn, history }: SearchModalPropsType) {
   const [categories, setCategories] = useState([]);
   const [checkedCategories, setCheckedCategories] = useState([] as boolean[]);
-
   const [checkedFinished, setCheckedFinished] = useState([false, false]);
   const currentLocation = useRecoilValue(locationState);
   const [location, setLocation] = useState<LocationType>(currentLocation);
@@ -129,9 +70,8 @@ function SearchModal({ setIsSearchModalOn, history }: { setIsSearchModalOn: any;
     if (JSON.stringify(location) !== JSON.stringify({ lat: 0, lng: 0 })) searchCoordinateToAddress(location);
   }, [location]);
   useEffect(() => {
-    fetchGet(`${process.env.REACT_APP_SERVER_URL}/api/category`).then(result => {
+    service.getCategories().then(result => {
       setCategories(result.map((x: any) => x.name));
-
       const query = decomposeQueryString(window.location.search);
       setCheckedCategories(checkedCategories => {
         const arr = new Array(result.length).fill(false);
@@ -220,4 +160,59 @@ function SearchModal({ setIsSearchModalOn, history }: { setIsSearchModalOn: any;
   );
 }
 
-export default SearchModal;
+const searchModal = css`
+  max-width: 700px;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100vw;
+  height: 100vh;
+  background-color: #fff7f7;
+  z-index: 1;
+  padding: 10px;
+`;
+
+const CategoryStyle = css`
+  & > h3 {
+    margin-bottom: 5px;
+  }
+  & > div {
+    display: flex;
+    flex-wrap: wrap;
+  }
+`;
+
+const ChipStyle = (checked: boolean) => {
+  return css`
+    width: 80px;
+    margin: 3px 3px;
+    ${checked ? 'background-color: #ebabab; color: #ffffff;' : ''}
+    &:hover {
+      background-color: #ebe4e4;
+      ${checked ? 'background-color: #ebabab;' : ''}
+    }
+  `;
+};
+
+const StateStyle = css`
+  & > h3 {
+    margin-bottom: 5px;
+  }
+  & > div {
+    display: flex;
+    flex-wrap: wrap;
+  }
+`;
+
+const LocationStyle = css`
+  & > h3 {
+    margin-bottom: 5px;
+  }
+  & > div {
+    display: flex;
+    flex-wrap: wrap;
+  }
+`;
+
+const buttonContainerStyle = css`
+  text-align: right;
+`;

--- a/client/src/common/search-modal/index.tsx
+++ b/client/src/common/search-modal/index.tsx
@@ -8,8 +8,8 @@ import { boolToNum, createQueryString, decomposeQueryString, finishedToBool, get
 import { LocationType } from '../../type';
 import service from '../../util/service';
 import FilterOption from './component/FilterOption';
-import SelectChip from './component/SelectChip';
 import ButtonSet from './component/ButtonSet';
+import Select from './component/Select';
 
 const FINISHED_LIST = ['공구중', '공구완료'];
 
@@ -34,22 +34,6 @@ export default function SearchModal({ setIsSearchModalOn, history }: SearchModal
     } catch (err: any) {
       setAddress('주소 정보 없음');
     }
-  };
-
-  const handleCategoryClick = (idx: number) => {
-    setCheckedCategories(checkedCategories => {
-      const arr = [...checkedCategories];
-      arr[idx] = !arr[idx];
-      return arr;
-    });
-  };
-
-  const handleFinishedClick = (idx: number) => {
-    setCheckedFinished(checkedFinished => {
-      const arr = [...checkedFinished];
-      arr[idx] = !arr[idx];
-      return arr;
-    });
   };
 
   const handleCancel = () => setIsSearchModalOn(false);
@@ -99,28 +83,10 @@ export default function SearchModal({ setIsSearchModalOn, history }: SearchModal
     <div css={searchModal}>
       <SearchInput value={search} setSearch={setSearch} />
       <FilterOption title="카테고리">
-        {categories.map((category, i) => (
-          <SelectChip
-            selected={checkedCategories[i]}
-            onClick={() => {
-              handleCategoryClick(i);
-            }}
-          >
-            {category}
-          </SelectChip>
-        ))}
+        <Select options={categories} selected={checkedCategories} setSelected={setCheckedCategories} />
       </FilterOption>
       <FilterOption title="공구 상태">
-        {FINISHED_LIST.map((finished, i) => (
-          <SelectChip
-            selected={checkedFinished[i]}
-            onClick={() => {
-              handleFinishedClick(i);
-            }}
-          >
-            {finished}
-          </SelectChip>
-        ))}
+        <Select options={FINISHED_LIST} selected={checkedFinished} setSelected={setCheckedFinished} />
       </FilterOption>
       <FilterOption title="위치">
         <div>

--- a/client/src/common/search-modal/index.tsx
+++ b/client/src/common/search-modal/index.tsx
@@ -5,11 +5,11 @@ import { locationState } from '../../store/location';
 import { useRecoilValue } from 'recoil';
 import MapDrawer from './component/MapDrawer';
 import SearchInput from './component/SearchInput';
-import { Chip } from '@mui/material';
 import { boolToNum, createQueryString, decomposeQueryString, finishedToBool, getAddressByGeocode } from '../../util';
 import { LocationType } from '../../type';
 import service from '../../util/service';
 import FilterOption from './component/FilterOption';
+import SelectChip from './component/SelectChip';
 
 const FINISHED_LIST = ['공구중', '공구완료'];
 
@@ -27,14 +27,14 @@ export default function SearchModal({ setIsSearchModalOn, history }: SearchModal
   const [address, setAddress] = useState('위치 확인 중');
   const [search, setSearch] = useState('');
 
-  async function searchCoordinateToAddress(latlng: any) {
+  const updateAddress = async (latlng: LocationType) => {
     try {
       const result = await getAddressByGeocode(latlng.lat, latlng.lng);
       setAddress(result);
     } catch (err: any) {
       setAddress('주소 정보 없음');
     }
-  }
+  };
 
   const handleCategoryClick = (idx: number) => {
     setCheckedCategories(checkedCategories => {
@@ -54,8 +54,6 @@ export default function SearchModal({ setIsSearchModalOn, history }: SearchModal
 
   const handleSubmitClick = () => {
     const query = {
-      offset: 0,
-      limit: 15,
       category: boolToNum(checkedCategories),
       finished: finishedToBool(checkedFinished),
       lat: location.lat,
@@ -67,7 +65,8 @@ export default function SearchModal({ setIsSearchModalOn, history }: SearchModal
   };
 
   useEffect(() => {
-    if (JSON.stringify(location) !== JSON.stringify({ lat: 0, lng: 0 })) searchCoordinateToAddress(location);
+    if (location.lat == 0 && location.lng == 0) return;
+    updateAddress(location);
   }, [location]);
 
   useEffect(() => {
@@ -99,26 +98,26 @@ export default function SearchModal({ setIsSearchModalOn, history }: SearchModal
         <SearchInput value={search} setSearch={setSearch} />
         <FilterOption title="카테고리">
           {categories.map((category, i) => (
-            <Chip
-              label={category}
-              css={ChipStyle(checkedCategories[i])}
+            <SelectChip
+              selected={checkedCategories[i]}
               onClick={() => {
                 handleCategoryClick(i);
               }}
-              data-idx={i}
-            />
+            >
+              {category}
+            </SelectChip>
           ))}
         </FilterOption>
         <FilterOption title="공구 상태">
           {FINISHED_LIST.map((finished, i) => (
-            <Chip
-              label={finished}
-              css={ChipStyle(checkedFinished[i])}
+            <SelectChip
+              selected={checkedFinished[i]}
               onClick={() => {
                 handleFinishedClick(i);
               }}
-              data-idx={i}
-            />
+            >
+              {finished}
+            </SelectChip>
           ))}
         </FilterOption>
         <FilterOption title="위치">
@@ -166,18 +165,6 @@ const searchModal = css`
   z-index: 1;
   padding: 10px;
 `;
-
-const ChipStyle = (checked: boolean) => {
-  return css`
-    width: 80px;
-    margin: 3px 3px;
-    ${checked ? 'background-color: #ebabab; color: #ffffff;' : ''}
-    &:hover {
-      background-color: #ebe4e4;
-      ${checked ? 'background-color: #ebabab;' : ''}
-    }
-  `;
-};
 
 const buttonContainerStyle = css`
   text-align: right;

--- a/client/src/common/search-modal/index.tsx
+++ b/client/src/common/search-modal/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import Button from '@mui/material/Button';
 import { css } from '@emotion/react';
 import { locationState } from '../../store/location';
 import { useRecoilValue } from 'recoil';
@@ -10,6 +9,7 @@ import { LocationType } from '../../type';
 import service from '../../util/service';
 import FilterOption from './component/FilterOption';
 import SelectChip from './component/SelectChip';
+import ButtonSet from './component/ButtonSet';
 
 const FINISHED_LIST = ['공구중', '공구완료'];
 
@@ -52,7 +52,9 @@ export default function SearchModal({ setIsSearchModalOn, history }: SearchModal
     });
   };
 
-  const handleSubmitClick = () => {
+  const handleCancel = () => setIsSearchModalOn(false);
+
+  const handleSubmit = () => {
     const query = {
       category: boolToNum(checkedCategories),
       finished: finishedToBool(checkedFinished),
@@ -62,6 +64,7 @@ export default function SearchModal({ setIsSearchModalOn, history }: SearchModal
     };
     const queryStr = createQueryString(query);
     history.push('/?' + queryStr);
+    setIsSearchModalOn(false);
   };
 
   useEffect(() => {
@@ -93,64 +96,39 @@ export default function SearchModal({ setIsSearchModalOn, history }: SearchModal
   }, []);
 
   return (
-    <div>
-      <div css={searchModal}>
-        <SearchInput value={search} setSearch={setSearch} />
-        <FilterOption title="카테고리">
-          {categories.map((category, i) => (
-            <SelectChip
-              selected={checkedCategories[i]}
-              onClick={() => {
-                handleCategoryClick(i);
-              }}
-            >
-              {category}
-            </SelectChip>
-          ))}
-        </FilterOption>
-        <FilterOption title="공구 상태">
-          {FINISHED_LIST.map((finished, i) => (
-            <SelectChip
-              selected={checkedFinished[i]}
-              onClick={() => {
-                handleFinishedClick(i);
-              }}
-            >
-              {finished}
-            </SelectChip>
-          ))}
-        </FilterOption>
-        <FilterOption title="위치">
-          <div>
-            <p>{address}</p>
-            <MapDrawer setLocation={setLocation} location={location} />
-          </div>
-        </FilterOption>
-        <div css={buttonContainerStyle}>
-          <Button
-            variant="contained"
-            style={{
-              backgroundColor: '#D9D5D5',
-              marginRight: '15px'
-            }}
-            onClick={e => {
-              setIsSearchModalOn(false);
+    <div css={searchModal}>
+      <SearchInput value={search} setSearch={setSearch} />
+      <FilterOption title="카테고리">
+        {categories.map((category, i) => (
+          <SelectChip
+            selected={checkedCategories[i]}
+            onClick={() => {
+              handleCategoryClick(i);
             }}
           >
-            취소
-          </Button>
-          <Button
-            variant="contained"
-            style={{ backgroundColor: '#ebabab' }}
-            onClick={e => {
-              handleSubmitClick();
-              setIsSearchModalOn(false);
+            {category}
+          </SelectChip>
+        ))}
+      </FilterOption>
+      <FilterOption title="공구 상태">
+        {FINISHED_LIST.map((finished, i) => (
+          <SelectChip
+            selected={checkedFinished[i]}
+            onClick={() => {
+              handleFinishedClick(i);
             }}
           >
-            완료
-          </Button>
+            {finished}
+          </SelectChip>
+        ))}
+      </FilterOption>
+      <FilterOption title="위치">
+        <div>
+          <p>{address}</p>
+          <MapDrawer setLocation={setLocation} location={location} />
         </div>
-      </div>
+      </FilterOption>
+      <ButtonSet onCancel={handleCancel} onSubmit={handleSubmit} />
     </div>
   );
 }
@@ -164,8 +142,4 @@ const searchModal = css`
   background-color: #fff7f7;
   z-index: 1;
   padding: 10px;
-`;
-
-const buttonContainerStyle = css`
-  text-align: right;
 `;


### PR DESCRIPTION
코드의 복잡도를 줄이기 위해 다음과 같이 조치하였습니다.

- 하위 컴포넌트로 만들어 별도 파일로 분리하였습니다. `search-modal/index.tsx`에서 스타일과 JSX 코드를 줄이는 것이 목적입니다.
  - `ButtonSet` : 취소 / 확인 버튼
  - `FilterOption` : 각 필터링 섹션(카테고리, 공구 상태, 위치)
  - `Select` : 여러 개의 `SelectChip`으로 구성된 리스트이며, Chip 클릭시 상태를 변경하는 것까지 담당
  - `SelectChip` : MUI의 `Chip`을 래핑
- `useEffect` 및 컴포넌트 내의 함수 일부 수정
- 카테고리 리스트를 서버에 요청하는 코드를 서비스로 분리하였습니다.
- 카테고리 리스트를 요청하던 중 에러가 발생하면 에러 메시지를 띄우도록 하였습니다. `useError` Hook을 사용하였습니다.