### PR TITLE
Refactor[#334] : 채팅페이지 소켓 에러처리, 보낼 수 있는 이미지 사이즈 증가 

### DIFF
--- a/client/src/page/chat/component/ChatInput.tsx
+++ b/client/src/page/chat/component/ChatInput.tsx
@@ -22,7 +22,7 @@ function ChatInput(props: ChatInputType) {
     try {
       const img = event.target.files[0];
       if (!isImage(img.name)) throw new Error(ERROR.FILE_TYPE);
-      if (img.size > 2 * 1024 * 1024) throw new Error(ERROR.FILE_SIZE);
+      if (img.size > 6 * 1024 * 1024) throw new Error(ERROR.FILE_SIZE);
       const formData = new FormData();
       formData.append('file', img);
       service.postFile(props.postId, formData);

--- a/client/src/page/chat/component/ChatList.tsx
+++ b/client/src/page/chat/component/ChatList.tsx
@@ -70,6 +70,7 @@ export default function ChatList({ postId, user, socket, popError }: ChatListTyp
   };
 
   useEffect(() => {
+    socket.on('sendError', (errorMsg: string) => popError(errorMsg));
     socket.on('receiveMsg', (user: number, userName: string, msg: string) => {
       const isMe = checkSender(user);
       const bottom =

--- a/client/src/page/chat/index.tsx
+++ b/client/src/page/chat/index.tsx
@@ -59,6 +59,7 @@ function Chat() {
 
   const setChatSocket = () => {
     socketRef.current.emit('joinRoom', postId);
+    socketRef.current.on('joinError', (errMessage: string) => popError(errMessage));
   };
 
   useEffect(() => {

--- a/server/socket/chat.ts
+++ b/server/socket/chat.ts
@@ -14,7 +14,6 @@ export const joinRoom = (socket: any, io: Server) => {
       socket.emit('joinError', ERROR.NOT_LOGGED_IN);
       return;
     }
-    console.log('user: ' + loginUser.id + ' has entered room: ' + postId);
     socket.join(String(postId));
 
     try {


### PR DESCRIPTION
- 로그인이 안되었을 때, 또는 데이터베이스에서 에러가 발생했을 때 해당에러들을 socket으로 emit해주도록 하였다.
- - 2MB로 사용하니 너무 작아서 6MB로 증가시켰습니다.