### PR TITLE
fix[#356] : 참여한 공동구매 가져오는 쿼리문 성능 개선

### DIFF
--- a/server/service/participant-service.ts
+++ b/server/service/participant-service.ts
@@ -79,13 +79,20 @@ const finishPost = async (postId: number, hostId: number) => {
 
 const getParticipationPosts = async (userId: number, limit: string | undefined, cursor: string | null = null) => {
   const db = await getDB().get();
-  const sql = `select p.id, p.title, p.content, p.capacity, p.deadline, p.finished, p.lat, p.long, category.name as category from (select postId from participant where userId = ${userId}) pa left join post p on pa.postId = p.id LEFT JOIN category
-	ON p.categoryId = category.id`;
-  let condition = ' ';
-  if (cursor !== null) condition += `WHERE p.id < ${cursor} `;
-  condition += `ORDER BY p.id DESC `;
-  condition += `LIMIT ${limit}`;
-  const result = await db.manager.query(sql + condition);
+  const sql = `select p.id, p.title, p.content, p.capacity, p.deadline, p.finished, p.lat, p.long, category.name as category
+    from (
+      select postId
+      from participant
+      where userId = ${userId}
+      ${cursor !== null ? `AND postId < ${cursor}` : ''}
+      order by postId DESC
+      limit ${limit}
+    ) pa
+    left join post p
+    on pa.postId = p.id
+    left join category
+    on p.categoryId = category.id`;
+  const result = await db.manager.query(sql);
   return result;
 };
 


### PR DESCRIPTION
- 마이 페이지에서 참여한 공동구매를 가져올때 슬로우 쿼리가 발생하였음 (참여자 테이블에 데이터가 많아지면 발생)
- 조인되는 참여자 테이블의 사이즈를 줄여 조인 비용을 절감하도록 개선