### PR TITLE
fix[#358] : 스타일 일부 수정

### DIFF
--- a/client/src/common/chip/index.tsx
+++ b/client/src/common/chip/index.tsx
@@ -16,6 +16,6 @@ const ChipStyle = (backgroundColor: string) => ({
   marginBottom: '5px',
   fontSize: '11px',
   padding: '0px',
-  width: '65px',
+  minWidth: '65px',
   height: '28px'
 });

--- a/client/src/common/login-modal/index.tsx
+++ b/client/src/common/login-modal/index.tsx
@@ -12,6 +12,7 @@ const modalBackground = css`
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(4px);
+  z-index: 2;
 `;
 
 const modal = css`

--- a/client/src/common/search-modal/component/ButtonSet.tsx
+++ b/client/src/common/search-modal/component/ButtonSet.tsx
@@ -26,5 +26,8 @@ const ButtonSetStyle = css`
 
 const ButtonStyle = (bgColor: string) => css`
   background-color: ${bgColor};
+  &:hover {
+    background-color: ${bgColor};
+  }
   margin-left: 15px;
 `;

--- a/client/src/page/detail/component/Bottom.tsx
+++ b/client/src/page/detail/component/Bottom.tsx
@@ -55,5 +55,6 @@ const StyledBox = styled(Box)(() => ({
   right: 0,
   left: 0,
   bottom: 0,
-  height: '4.5rem'
+  height: '4.5rem',
+  zIndex: 2
 }));

--- a/client/src/page/detail/component/DeadLine.tsx
+++ b/client/src/page/detail/component/DeadLine.tsx
@@ -15,7 +15,15 @@ function DeadLine({ isNeedServerTime, deadline }: DeadLineType, ref: React.Ref<u
   useImperativeHandle(ref, () => ({
     setDeadLine: (endTime: string) => setEndTime(endTime)
   }));
-  return <Typography variant="body2">마감시간| {!isNeedServerTime ? endTime : '계산 중...'}</Typography>;
+  return (
+    <Typography variant="body2" sx={DeadlineStyle}>
+      {!isNeedServerTime ? endTime : '계산 중...'}
+    </Typography>
+  );
 }
+
+const DeadlineStyle = {
+  marginTop: '5px'
+};
 
 export default forwardRef(DeadLine);

--- a/client/src/page/detail/component/Header.tsx
+++ b/client/src/page/detail/component/Header.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Typography, Box, Avatar } from '@mui/material';
 import DeadLine from './DeadLine';
 import CategoryChip from '../../../common/chip/CategoryChip';
+import { css } from '@emotion/react';
 
 interface HeaderType {
   title: string;
@@ -20,8 +21,10 @@ export interface UserType {
 export default function Header({ title, categoryName, writer, deadline, isNeedServerTime, deadLineRef }: HeaderType) {
   return (
     <>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-        <Typography variant="h5">{title}</Typography>
+      <Box sx={{ display: 'flex', justifyContent: 'stretch' }}>
+        <Typography variant="h6" css={titleStyle}>
+          {title}
+        </Typography>
         <CategoryChip label={categoryName} />
       </Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2 }}>
@@ -34,3 +37,11 @@ export default function Header({ title, categoryName, writer, deadline, isNeedSe
     </>
   );
 }
+
+const titleStyle = css`
+  word-break: break-all;
+  flex-grow: 1;
+  margin: 0;
+  margin-right: 10px;
+  margin-top: -2px;
+`;

--- a/client/src/page/detail/component/LinkPreview.tsx
+++ b/client/src/page/detail/component/LinkPreview.tsx
@@ -25,7 +25,7 @@ export default function LinkPreview({ url }: { url: string }) {
 
   return (
     <a css={PreviewContainerStyle} target="_blank" href={url} rel="noreferrer">
-      <div style={{ flex: '3', marginRight: '5px' }}>
+      <div style={{ width: 'calc(100% - 64px - 10px)' }}>
         {!isLoading ? (
           <>
             <h4 css={PreviewTitleStyle}>{metadata ? metadata.title : url}</h4>
@@ -34,7 +34,7 @@ export default function LinkPreview({ url }: { url: string }) {
           </>
         ) : (
           <>
-            <Skeleton />
+            <Skeleton width="80%" />
             <Skeleton width="60%" />
           </>
         )}
@@ -42,12 +42,12 @@ export default function LinkPreview({ url }: { url: string }) {
       {!isLoading ? (
         <img
           src={metadata && metadata.image ? metadata.image : noImg}
-          style={{ maxWidth: '30%', maxHeight: 64 }}
+          style={{ width: 70, maxHeight: 70 }}
           alt={metadata && metadata.title}
         />
       ) : (
-        <div style={{ flex: '1' }}>
-          <Skeleton variant="rectangular" height={64} />
+        <div>
+          <Skeleton variant="rectangular" width={70} height={70} />
         </div>
       )}
     </a>
@@ -55,7 +55,9 @@ export default function LinkPreview({ url }: { url: string }) {
 }
 
 const PreviewContainerStyle = css`
+  position: relative;
   display: flex;
+  justify-content: space-between;
   align-items: center;
   border-radius: 5px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), 0 -4px 24px 2px rgba(0, 0, 0, 0.03);
@@ -76,8 +78,7 @@ const PreviewTitleStyle = css`
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  margin: 5px 0;
-  max-width: 60vw;
+  margin: 0;
 `;
 
 const PreviewDescStyle = css`

--- a/client/src/page/detail/index.tsx
+++ b/client/src/page/detail/index.tsx
@@ -59,7 +59,7 @@ export default function Detail({ match }: RouteComponentProps<DetailType>) {
           return;
         } else {
           const { days, hours, minutes, seconds } = getRemainingDay(endTime, serverTime);
-          deadLineRef.current.setDeadLine(days + '일 ' + hours + ':' + minutes + ':' + seconds);
+          deadLineRef.current.setDeadLine(`${days}일 ${hours}:${minutes}:${seconds} 남음`);
           return;
         }
       }

--- a/client/src/page/main/component/FAB.tsx
+++ b/client/src/page/main/component/FAB.tsx
@@ -10,6 +10,9 @@ const FabStyle = css`
   position: fixed;
   right: 30px;
   bottom: 30px;
+  @media (min-width: 700px) {
+    right: calc(50vw - 350px + 30px);
+  }
 `;
 
 export default function FAB({ loginUser }: { loginUser: LoginUserType }) {


### PR DESCRIPTION
### 1. 서치 모달
- hover 상태에서 버튼이 파란색으로 바뀌는 문제 수정

### 2. 로그인 모달
- 메인 페이지와 상세 페이지에서 로그인 모달의 배경이 GNB 아래로 깔리는 문제 수정

### 3. 상세 페이지
- 긴 제목을 출력할 경우 끝을 "..." 처리하지 않고, 여러 줄로 모두 출력하도록 변경
- 마감 기한 텍스트 형식 수정 `마감기한| 3일 5:00:00` -> `3일 5:00:00 남음`
- 마감 기한 텍스트 스타일 수정 `margin-top: 5px`

### 4. FAB
- 큰 화면에서도 메인 페이지 컨테이너 안에 FAB가 위치하도록 조정

### 5. LinkPreview
- 제목이 긴 경우에 링크 프리뷰를 벗어나는 문제 해결
- 이미지 사이즈 소폭 상향