### PR TITLE
bug[#360] : 상세 페이지 제목 버그 수정

### DIFF
--- a/client/src/page/detail/component/Header.tsx
+++ b/client/src/page/detail/component/Header.tsx
@@ -21,7 +21,9 @@ export default function Header({ title, categoryName, writer, deadline, isNeedSe
   return (
     <>
       <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-        <Typography variant="h5">{title}</Typography>
+        <Typography noWrap variant="h5" sx={{ width: '80%' }}>
+          {title}
+        </Typography>
         <CategoryChip label={categoryName} />
       </Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2 }}>


### PR DESCRIPTION
## ⛅️ 내용

> 이 PR의 작업 요약

- 상세 페이지 제목이 긴 경우에 화면을 벗어나고 카테고리 칩이 보이지 않는 버그 수정

## 🎸특이사항

> 리뷰시 참고할만한 내용, 주의깊게 봐줬으면 하는 내용

-

## 문제점